### PR TITLE
docs: refine and beautify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,125 +1,110 @@
-# Busters — CEM-trained Codingame bot (monorepo)
+# Busters — CEM-Trained Codingame Bot (Monorepo)
 
-This repo evolves a **Codingame “Busters”** bot using the **Cross-Entropy Method (CEM)**, evaluates it against a pool of opponents, and exports a **single-file** Codingame-legal bot (`readline()` loop).
+Evolves a [Codingame "Busters"](https://www.codingame.com/multiplayer/bot-programming/busters) bot using the **Cross-Entropy Method (CEM)**. Trains against a pool of opponents and exports a single-file bot (`readline()` loop) compatible with the Codingame IDE.
 
-> **Current state (last successful run):**
-> - Serial sanity ✅
-> - Parallel training ✅
-> - Best genome example: `{ "radarTurn": 23, "stunRange": 1766, "releaseDist": 1600 }`
-> - Fitness ≈ 2.28
-> - Exporter writes `my_cg_bot.js`
-> - Tournament works (`greedy`, `random`, `evolved` resolved correctly)
+## Table of Contents
+- [Current Status](#current-status)
+- [Repository Structure](#repository-structure)
+- [Quick Start](#quick-start)
+- [Export a Codingame Bot](#export-a-codingame-bot)
+- [Run Local Tournaments](#run-local-tournaments)
+- [View Replays](#view-replays)
+- [Troubleshooting](#troubleshooting)
+- [Roadmap](#roadmap)
 
----
+## Current Status
+- Serial sanity ✅
+- Parallel training ✅
+- Best genome example: `{ "radarTurn": 23, "stunRange": 1766, "releaseDist": 1600 }`
+- Fitness ≈ 2.28
+- Exporter writes `my_cg_bot.js`
+- Tournament works (`greedy`, `random`, `evolved` resolved correctly)
 
-## Monorepo layout
-
+## Repository Structure
+```
 packages/
-agents/ # baseline & evolved adapters (greedy-buster.js, random-bot.js, evolved-bot.js)
-engine/ # core sim (state, step, perception, scoring)
-shared/ # constants, RNG, types, vec helpers
-sim-runner/ # training + tournaments (CEM, PFSP/Elo, workers, artifacts)
-viewer/ # Vite replay viewer (reads JSON from public/replays/)
+agents/           # baseline & evolved adapters
+engine/           # core simulation: state, step, perception, scoring
+shared/           # constants, RNG, types, vector helpers
+sim-runner/       # training + tournaments (CEM, PFSP/Elo, workers, artifacts)
+viewer/           # Vite replay viewer (reads JSON from public/replays/)
 scripts/
-export-cg-bot.ts # exports Codingame bot -> my_cg_bot.js
+export-cg-bot.ts  # exports Codingame bot -> my_cg_bot.js
+```
 
-
-
-Key control flow:
-- `packages/sim-runner/src/cli.ts`  
-  - `train` → `ga.ts::trainCEM`  
-  - `tourney` → round-robin, saves replays + standings  
-- `ga.ts`  
-  - CEM sampling + EMA smoothing  
-  - PFSP opponent pick + Elo updates  
-  - Serial and parallel eval (workers)  
-  - Writes: `artifacts/simrunner_best_genome.json`, `league_elo.json`  
-- Export: `scripts/export-cg-bot.ts` → `my_cg_bot.js` (CG `readline()` format)
-
----
-
-## Quick start
+## Quick Start
 
 ### Install
 ```bash
 pnpm install
 pnpm add -w -D tsx
+```
 
-### Smoke train
-
+### Smoke Train
+```bash
 pnpm -C packages/sim-runner start train \
   --algo cem --pop 8 --gens 2 \
   --seeds-per 2 --eps-per-seed 1 \
   --jobs 1 --seed 42 \
   --opp-pool greedy,random \
   --hof 3
+```
 
-### Parallel train
-
+### Parallel Train
+```bash
 pnpm -C packages/sim-runner start train \
   --algo cem --pop 24 --gens 8 \
   --seeds-per 5 --eps-per-seed 2 \
   --jobs 8 --seed 42 \
   --opp-pool greedy,random \
   --hof 5
+```
 
-## Export a Codingame bot
+## Export a Codingame Bot
+Generate a single-file `my_cg_bot.js` (no imports; uses `readline()` + `console.log()`):
 
-Generates my_cg_bot.js (no imports; uses readline() + console.log()):
-
+```bash
 pnpm make:cg
+```
 
-The exporter reads packages/sim-runner/artifacts/simrunner_best_genome.json (or artifacts/simrunner_best_genome.json fallback).
-If not found, it falls back to a known good genome.
+The exporter reads `packages/sim-runner/artifacts/simrunner_best_genome.json` (or `artifacts/simrunner_best_genome.json` fallback). If not found, it falls back to a known good genome. Paste the resulting `my_cg_bot.js` into the Codingame IDE.
 
-Paste the resulting my_cg_bot.js into the Codingame IDE.
+## Run Local Tournaments
+Short names `greedy`, `random`, `evolved` are resolved by the loader to absolute file paths.
 
-## Run tournaments (local)
-
-Short names greedy,random,evolved are resolved by the loader to absolute file paths.
-
-
+```bash
 pnpm -C packages/sim-runner start tourney \
   --bots greedy,random,evolved \
   --seeds 50 \
   --save-dir ../../viewer/public/replays/tourney
+```
 
 Artifacts:
+- `packages/sim-runner/artifacts/tournament_standings.json`
+- Replays in `packages/viewer/public/replays/...`
 
-packages/sim-runner/artifacts/tournament_standings.json
-
-Replays in packages/viewer/public/replays/...
-
-
-## View replays 
-
+## View Replays
+```bash
 pnpm -C packages/viewer dev
 # open http://localhost:5173
+```
 
+## Troubleshooting
 
-# Troubleshooting
-
-tsx: command not found
-Install at workspace root:
-
-pnpm add -w -D tsx
-
-Tourney: Cannot find package 'packages' imported from .../loadBots.ts
-Ensure the loader maps short names to absolute file paths (already fixed here).
-
-CG bot runs locally but not in IDE
-Check that the export is a single file, uses readline()/console.log(), and prints exactly one action per buster each turn.
-
-
+- **`tsx: command not found`**  
+  Install at workspace root:
+  ```bash
+  pnpm add -w -D tsx
+  ```
+- **Tourney: Cannot find package 'packages' imported from .../loadBots.ts**  
+  Ensure the loader maps short names to absolute file paths (already fixed here).
+- **CG bot runs locally but not in IDE**  
+  Check that the export is a single file, uses `readline()`/`console.log()`, and prints exactly one action per buster each turn.
 
 ## Roadmap
+- Enrich opponent pool with disruptors (base camper, aggressive stunner).
+- Add HoF export & automatic pool refresh.
+- Add telemetry in replays (action tags).
+- Exporter variants (patrol heuristics).
+- CI: smoke train + tourney on PRs.
 
-Enrich opponent pool with disruptors (base camper, aggressive stunner).
-
-Add HoF export & automatic pool refresh.
-
-Add telemetry in replays (action tags).
-
-Exporter variants (patrol heuristics).
-
-CI: smoke train + tourney on PRs.


### PR DESCRIPTION
## Summary
- reorganize README with table of contents and clearer sections
- clarify training, exporting, and tournament commands
- polish repository overview and troubleshooting notes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a05ff9ebcc832b9783481e70135908