### PR TITLE
Handle replays without debug tags in replay-report

### DIFF
--- a/packages/sim-runner/scripts/replay-report.ts
+++ b/packages/sim-runner/scripts/replay-report.ts
@@ -132,8 +132,12 @@ async function main() {
     return;
   }
 
-  // If any frame has actions, we’ll use tag-based mode.
-  const actionsExist = !!frames.find((f) => (f as any).actionsA || (f as any).actionsB);
+  // If any action contains a debug tag, we'll use tag-based mode. Otherwise,
+  // fall back to inferring events from state changes.
+  const actionsExist = frames.some((f) =>
+    (f as any).actionsA?.some((a: any) => a?.__dbg?.tag || a?.tag) ||
+    (f as any).actionsB?.some((a: any) => a?.__dbg?.tag || a?.tag)
+  );
 
   const tagCountCombined = new Map<string, number>();
   const tagCountA = new Map<string, number>();


### PR DESCRIPTION
## Summary
- fall back to inference when replays have actions but no debug tags

## Testing
- `pnpm --dir packages/sim-runner exec tsx scripts/replay-report.ts /tmp/test_replay.json`
- `pnpm --dir packages/sim-runner exec tsx scripts/replay-report.ts /tmp/test_replay_tags.json`


------
https://chatgpt.com/codex/tasks/task_e_68a48fe79e74832bb24b04c71569daf7