### PR TITLE
Add unit tests for shared utilities

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,5 +5,12 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.4",
+    "typescript": "^5.5.4"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts"
   }
 }

--- a/packages/shared/src/rng.test.ts
+++ b/packages/shared/src/rng.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { XorShift32 } from './rng';
+
+test('XorShift32 generates a deterministic sequence', () => {
+  const rng = new XorShift32(1);
+  assert.equal(rng.int(), 270369);
+  assert.equal(rng.int(), 67634689);
+});
+
+test('XorShift32 float output is within [0, 1)', () => {
+  const rng = new XorShift32(123);
+  for (let i = 0; i < 5; i++) {
+    const v = rng.float();
+    assert.ok(v >= 0 && v < 1);
+  }
+});

--- a/packages/shared/src/vec.test.ts
+++ b/packages/shared/src/vec.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { clamp, dist, dist2, norm, roundi } from './vec';
+
+test('clamp limits value within range', () => {
+  assert.equal(clamp(5, 0, 10), 5);
+  assert.equal(clamp(-1, 0, 10), 0);
+  assert.equal(clamp(11, 0, 10), 10);
+});
+
+test('dist and dist2 compute distances correctly', () => {
+  assert.equal(dist2(0, 0, 3, 4), 25);
+  assert.equal(dist(0, 0, 3, 4), 5);
+});
+
+test('norm returns a unit vector and handles zero length', () => {
+  const [x, y] = norm(3, 4);
+  assert.ok(Math.abs(x - 0.6) < 1e-9);
+  assert.ok(Math.abs(y - 0.8) < 1e-9);
+  const [zx, zy] = norm(0, 0);
+  assert.equal(zx, 0);
+  assert.equal(zy, 0);
+});
+
+test('roundi rounds to nearest integer', () => {
+  assert.equal(roundi(3.2), 3);
+  assert.equal(roundi(3.5), 4);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,14 @@ importers:
         specifier: ^4.16.2
         version: 4.20.4
 
-  packages/shared: {}
+  packages/shared:
+    devDependencies:
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
 
   packages/sim-runner:
     dependencies:


### PR DESCRIPTION
## Summary
- add tests for vector math helpers
- add deterministic and range tests for XorShift32 RNG
- configure shared package to run tests via tsx

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49ec52830832b887d9aef9887c9e7