### PR TITLE
Add initGame bounds test for engine

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -8,5 +8,12 @@
   },
   "dependencies": {
     "@busters/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.4",
+    "typescript": "^5.5.4"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts"
   }
 }

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { initGame } from './engine';
+import { MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
+
+test('initGame sets up teams and ghosts within bounds', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 2, ghostCount: 3 });
+  assert.equal(state.busters.length, 4);
+  assert.equal(state.ghosts.length, 3);
+
+  for (const b of state.busters) {
+    if (b.teamId === 0) {
+      const dx = Math.abs(b.x - TEAM0_BASE.x);
+      const dy = Math.abs(b.y - TEAM0_BASE.y);
+      assert.ok(dx <= 200 && dy <= 200);
+    } else {
+      const dx = Math.abs(b.x - TEAM1_BASE.x);
+      const dy = Math.abs(b.y - TEAM1_BASE.y);
+      assert.ok(dx <= 200 && dy <= 200);
+    }
+  }
+
+  for (const g of state.ghosts) {
+    assert.ok(g.x >= 500 && g.x <= MAP_W - 500);
+    assert.ok(g.y >= 500 && g.y <= MAP_H - 500);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,19 +26,13 @@ importers:
       '@busters/shared':
         specifier: workspace:*
         version: link:../shared
-
-  packages/evolve:
-    dependencies:
-      '@busters/shared':
-        specifier: workspace:*
-        version: link:../shared
-      '@busters/sim-runner':
-        specifier: workspace:*
-        version: link:../sim-runner
     devDependencies:
       tsx:
-        specifier: ^4.16.2
+        specifier: ^4.20.4
         version: 4.20.4
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
## Summary
- add test for initGame verifying busters and ghosts positions
- configure engine package with test script and dev deps

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a17eb0a8832babdbb0600a608fd2