### PR TITLE
fix: ensure rng float output always <1

### DIFF
--- a/packages/shared/src/rng.test.ts
+++ b/packages/shared/src/rng.test.ts
@@ -8,10 +8,17 @@ test('XorShift32 generates a deterministic sequence', () => {
   assert.equal(rng.int(), 67634689);
 });
 
-test('XorShift32 float output is within [0, 1)', () => {
+test('XorShift32 float output is within [0, 1) and never equals 1', () => {
   const rng = new XorShift32(123);
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 1_000_000; i++) {
     const v = rng.float();
     assert.ok(v >= 0 && v < 1);
   }
+});
+
+test('XorShift32 float handles max int without returning 1', () => {
+  // Seed computed to make the first int() call return 0xFFFFFFFF
+  const rng = new XorShift32(1584200935);
+  const v = rng.float();
+  assert.ok(v < 1);
 });

--- a/packages/shared/src/rng.ts
+++ b/packages/shared/src/rng.ts
@@ -10,5 +10,5 @@ export class XorShift32 {
     this._state = x >>> 0;
     return this._state;
   }
-  float(): number { return (this.int() >>> 0) / 0xFFFFFFFF; }
+  float(): number { return (this.int() >>> 0) / 0x100000000; }
 }


### PR DESCRIPTION
## Summary
- ensure XorShift32.float divides by 2^32 so results are always below 1
- extend RNG tests to sample many values and verify max int case doesn't return 1

## Testing
- `pnpm -C packages/shared test`

------
https://chatgpt.com/codex/tasks/task_e_68a4acfa0e40832b99a737e31be4e55f