### PR TITLE
feat: implement CEM trainer for weights

### DIFF
--- a/packages/sim-runner/src/algos/cem-utils.ts
+++ b/packages/sim-runner/src/algos/cem-utils.ts
@@ -1,0 +1,42 @@
+export function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function gaussian(rng: () => number) {
+  let u = 0, v = 0;
+  while (u === 0) u = rng();
+  while (v === 0) v = rng();
+  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+}
+
+export function vecMean(vs: number[][]): number[] {
+  const n = vs.length;
+  const d = vs[0].length;
+  const out = new Array(d).fill(0);
+  for (const v of vs) {
+    for (let i = 0; i < d; i++) out[i] += v[i];
+  }
+  for (let i = 0; i < d; i++) out[i] /= n;
+  return out;
+}
+
+export function vecVar(vs: number[][], m: number[]): number[] {
+  const n = vs.length;
+  const d = m.length;
+  const out = new Array(d).fill(0);
+  for (const v of vs) {
+    for (let i = 0; i < d; i++) {
+      const dv = v[i] - m[i];
+      out[i] += dv * dv;
+    }
+  }
+  const denom = Math.max(1, n - 1);
+  for (let i = 0; i < d; i++) out[i] /= denom;
+  return out;
+}

--- a/packages/sim-runner/src/algos/cem-weights.test.ts
+++ b/packages/sim-runner/src/algos/cem-weights.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { trainCemWeights } from './cem-weights';
+import { weightsToVec } from '../genomes/weightsGenome';
+import { DEFAULT_WEIGHTS } from '../../../agents/weights';
+
+// simple helper
+function dist2(a: number[], b: number[]) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) {
+    const d = a[i] - b[i];
+    s += d * d;
+  }
+  return s;
+}
+
+test('trainCemWeights moves mean toward target', async () => {
+  const base = weightsToVec(DEFAULT_WEIGHTS);
+  const target = base.map((v) => v + 1); // arbitrary optimum
+
+  const evalFn = async (w: any, _opp: string) => {
+    const vec = weightsToVec(w);
+    return -dist2(vec, target);
+  };
+
+  const res = await trainCemWeights({
+    gens: 2,
+    pop: 32,
+    elitePct: 0.25,
+    seed: 123,
+    oppPool: ['greedy', 'random'],
+    evaluate: evalFn,
+  });
+
+  assert.equal(res.mean.length, base.length);
+  const baseDist = dist2(base, target);
+  const newDist = dist2(res.mean, target);
+  assert.ok(newDist < baseDist, 'mean should move toward target');
+});

--- a/packages/sim-runner/src/algos/cem-weights.ts
+++ b/packages/sim-runner/src/algos/cem-weights.ts
@@ -4,9 +4,57 @@
  *    update mean/cov, repeat.
  */
 import { vecToWeights, weightsToVec } from "../genomes/weightsGenome";
-// TODO: import your existing CEM utilities here and specialize for dimension = weightsToVec(DEFAULT).length
+import { DEFAULT_WEIGHTS, type Weights } from "../../../agents/weights";
+import { selectOpponentsPFSP } from "../pfsp";
+import { gaussian, mulberry32, vecMean, vecVar } from "./cem-utils";
 
-export async function trainCemWeights(/* params */){
-  // TODO: integrate with your existing training loop
-  return null;
+// Dimension of the flat weight vector
+const DIM = weightsToVec(DEFAULT_WEIGHTS).length;
+
+export type TrainOpts = {
+  gens: number;
+  pop: number;
+  elitePct: number;
+  seed: number;
+  oppPool: string[];
+  evaluate: (w: Weights, oppId: string) => Promise<number>;
+};
+
+/** Train weights using a simple diagonal-covariance CEM loop. */
+export async function trainCemWeights(opts: TrainOpts) {
+  const { gens, pop, elitePct, seed, oppPool, evaluate } = opts;
+  const rng = mulberry32(seed >>> 0);
+
+  let mean = weightsToVec(DEFAULT_WEIGHTS);
+  let cov = new Array(DIM).fill(1);
+  const eliteCount = Math.max(1, Math.floor(pop * elitePct));
+
+  for (let g = 0; g < gens; g++) {
+    // --- Sample population ---
+    const popVecs: number[][] = [];
+    for (let i = 0; i < pop; i++) {
+      const v: number[] = [];
+      for (let d = 0; d < DIM; d++) {
+        v[d] = mean[d] + Math.sqrt(cov[d]) * gaussian(rng);
+      }
+      popVecs.push(v);
+    }
+
+    // --- Evaluate via PFSP-opponent sampling ---
+    const evals: { idx: number; fit: number }[] = [];
+    for (let i = 0; i < pop; i++) {
+      const w = vecToWeights(popVecs[i]);
+      const opp = selectOpponentsPFSP({ meId: "weights", candidates: oppPool, n: 1 })[0].id;
+      const fit = await evaluate(w, opp);
+      evals.push({ idx: i, fit });
+    }
+    evals.sort((a, b) => b.fit - a.fit);
+
+    // --- Update mean & covariance from elites ---
+    const elites = evals.slice(0, eliteCount).map((e) => popVecs[e.idx]);
+    mean = vecMean(elites);
+    cov = vecVar(elites, mean);
+  }
+
+  return { mean, cov };
 }


### PR DESCRIPTION
## Summary
- specialize CEM utilities for weight-vector dimension and implement training loop with PFSP evaluation and mean/covariance updates
- add reusable CEM math utilities
- include a smoke test to ensure the trainer updates its mean toward a target vector

## Testing
- `npx tsx --test packages/sim-runner/src/algos/cem-weights.test.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ad1a662c832b9de96e49df5ce263