### PR TITLE
chore: remove milestone references

### DIFF
--- a/agents/codingame-bot.js
+++ b/agents/codingame-bot.js
@@ -1,5 +1,5 @@
 /**
- * CodinGame Busters — EVOL2 exporter (Milestone M2)
+ * CodinGame Busters — EVOL2 exporter
  * Single-file bot generated from local training/tournament artifacts.
  */
 

--- a/fix.sh
+++ b/fix.sh
@@ -1,11 +1,11 @@
 cat > packages/agents/hybrid-bot.ts <<'TS'
-/** EVOL2 — Milestone M1: Hybrid with tiny POMDP scaffolding
+/** EVOL2 — Hybrid with tiny POMDP scaffolding
  *  - Uses a coarse visit grid for frontier exploration under fog
  *  - Tracks enemy last-seen (pos, carrying, stunCd)
  *  - Safe RADAR schedule (staggered), ring busting, carry→release
  */
 
-export const meta = { name: "HybridBaseline", version: "M1" };
+export const meta = { name: "HybridBaseline", version: "1" };
 
 import { HybridState, getState, Pt } from "./lib/state";
 

--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -1,4 +1,4 @@
-/** Minimal fog-of-war & frontier selector for Busters (EVOL2 M3)
+/** Minimal fog-of-war & frontier selector for Busters (EVOL2)
  *  - Grid covers 16000x9000 with 400px cells => 40 x 23
  *  - Tracks last-visited tick per cell
  *  - Tracks a soft "ghost belief" heat value per cell (decays each tick)

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -1,4 +1,4 @@
-/** Hybrid baseline with auction/assignment (EVOL2 M4…M8, with __dbg tags) */
+/** Hybrid baseline with auction/assignment (with __dbg tags) */
 export const meta = { name: "HybridBaseline" };
 
 // Params are imported so CEM can overwrite them.

--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -1,4 +1,4 @@
-/** EVOL2 — M1: minimal shared state for the hybrid bot.
+/** EVOL2 — minimal shared state for the hybrid bot.
  *  - Coarse visit grid for frontier-style exploration under fog
  *  - Enemy last-seen tracking (pos, tick, carrying, stunCd)
  *  Keep it tiny and robust; we’ll extend later (ghost probs, priors, etc.).

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -1,4 +1,4 @@
-/** Tiny, fast "micro-rollout" heuristics used inside assignment scores (EVOL2 M5). */
+/** Tiny, fast "micro-rollout" heuristics used inside assignment scores. */
 /** No external deps; keep everything numerically cheap. */
 
 type Pt = { x: number; y: number };

--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -5,7 +5,7 @@ import { loadBotModule } from './loadBots';
 import { runEpisodes } from './runEpisodes';
 import { runRoundRobin } from './tournament';
 
-// Hybrid subject (EVOL2 M6+)
+// Hybrid subject (EVOL2)
 import {
   ORDER,
   baselineVec,

--- a/scripts/export-codingame.ts
+++ b/scripts/export-codingame.ts
@@ -37,7 +37,7 @@ function writeOut(code: string) {
 function cgHeader(): string {
   return [
     "/**",
-    " * CodinGame Busters — EVOL2 exporter (Milestone M2)",
+    " * CodinGame Busters — EVOL2 exporter",
     " * Single-file bot generated from local training/tournament artifacts.",
     " */",
     "",
@@ -155,7 +155,7 @@ function makeGenomeBot(g: Genome): string {
   return cgHeader() + "\n" + body + "\n";
 }
 
-// --- HYBRID baseline (M2). Same as above but with a bit richer defaults & 2 radars.
+// --- HYBRID baseline. Same as above but with a bit richer defaults & 2 radars.
 function makeHybridBot(weights?: Partial<Genome> & { radar2Turn?: number }) {
   const w = {
     radarTurn: 2,


### PR DESCRIPTION
## Summary
- strip milestone labels from comments and metadata
- tidy exporter and CLI headers

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4be368ca0832b8bf70b32baaf0d89