### PR TITLE
Gracefully handle missing PFSP log files

### DIFF
--- a/scripts/pfsp-report.ts
+++ b/scripts/pfsp-report.ts
@@ -31,9 +31,10 @@ const candidates = [
   path.resolve('artifacts/pfsp_log.jsonl'),
 ];
 const logPath = explicitLog ? path.resolve(explicitLog) : candidates.find(p => fs.existsSync(p));
-if (!logPath) {
-  console.error('pfsp-report: no PFSP log found at', [explicitLog, ...candidates].join(' or '));
-  process.exit(1);
+if (!logPath || !fs.existsSync(logPath)) {
+  const locations = [explicitLog, ...candidates].filter(Boolean).join(' or ');
+  console.log('pfsp-report: no PFSP log found at', locations);
+  process.exit(0);
 }
 
 type Row = {


### PR DESCRIPTION
## Summary
- Avoid crashing `pfsp-report` when the specified PFSP log file is absent
- Provide a friendly message and exit cleanly when no log file is available

## Testing
- `pnpm test`
- `pnpm pfsp:report /tmp/nonexistent.log`


------
https://chatgpt.com/codex/tasks/task_e_68a4caaa38e4832ba5247a1efe9c7116