### PR TITLE
Reset hybrid bot memory at match start

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { act, __mem } from './hybrid-bot';
+
+test('mem resets on new match and repopulates', () => {
+  // pre-populate with stale entry
+  __mem.set(99, { stunReadyAt: 5, radarUsed: true, wp: 1 });
+
+  const ctx: any = {};
+  const baseObs: any = { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
+  act(ctx, baseObs);
+  assert.ok(!__mem.has(99));
+  assert.ok(__mem.has(1));
+
+  const nextObs: any = { tick: 2, self: { id: 2, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
+  act(ctx, nextObs);
+  assert.ok(__mem.has(1) && __mem.has(2));
+});

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -55,7 +55,9 @@ type Obs = {
 
 /** Memory per buster */
 const mem = new Map<number, { stunReadyAt: number; radarUsed: boolean; wp: number }>();
+export const __mem = mem; // exposed for tests
 function M(id: number) { if (!mem.has(id)) mem.set(id, { stunReadyAt: 0, radarUsed: false, wp: 0 }); return mem.get(id)!; }
+let lastTick = Infinity;
 
 /** Patrol paths used as exploration frontiers (simple & fast) */
 const PATROLS: Pt[][] = [
@@ -263,9 +265,11 @@ function runAuction(team: Ent[], tasks: Task[], enemies: Ent[], MY: Pt, tick: nu
 
 /** --- Main per-buster policy --- */
 export function act(ctx: Ctx, obs: Obs) {
+  const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
+  if (tick <= 1 && tick < lastTick) mem.clear();
+  lastTick = tick;
   const me = obs.self;
   const m = M(me.id);
-  const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
   const state = getState(ctx, obs);
   state.trackEnemies(obs.enemies, tick);
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -17,10 +17,13 @@
     "./hof": "./hof.ts"
   },
   "devDependencies": {
-    "esbuild": "^0.25.9"
+    "esbuild": "^0.25.9",
+    "tsx": "^4.20.4",
+    "typescript": "^5.5.4"
   },
   "scripts": {
     "build": "echo \"@busters/agents: nothing to build\"",
-    "build:cg": "esbuild cg-adapter.ts --bundle --format=iife --target=es2019 --outfile=dist/hybrid-cg.js"
+    "build:cg": "esbuild cg-adapter.ts --bundle --format=iife --target=es2019 --outfile=dist/hybrid-cg.js",
+    "test": "tsx --test *.test.ts"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       esbuild:
         specifier: ^0.25.9
         version: 0.25.9
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
 
   packages/engine:
     dependencies:


### PR DESCRIPTION
## Summary
- Clear hybrid bot's global mem on new matches to avoid stale state
- Expose mem for tests and add coverage
- Wire up agents package tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4cee64d30832b867fc3ee58d4e8a4