### PR TITLE
feat: prune stale enemies

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -4,3 +4,10 @@ Export two things:
 - `meta` → { name, version }.
 
 Use `pnpm dev` to run the viewer and load your bot modules for each team.
+
+### Enemy memory pruning
+
+`HybridState` remembers where enemies were last seen. To avoid stale data, entries
+older than `enemyMaxAge` ticks (default **40**) are discarded. The threshold can
+be tuned by passing a different value when constructing `HybridState` or by
+calling `state.pruneEnemies(currentTick, maxAge)` manually.


### PR DESCRIPTION
## Summary
- add configurable enemy memory pruning to `HybridState`
- document enemy memory threshold and usage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4cef52508832ba2c5ea1c6e25ca20