### PR TITLE
refactor: use shared map constants in agents

### DIFF
--- a/packages/agents/cg-adapter.ts
+++ b/packages/agents/cg-adapter.ts
@@ -11,10 +11,11 @@ declare function readline(): string;
 declare function print(s: string): void;
 
 import { act } from "./hybrid-bot";
+import { MAP_W, MAP_H } from "@busters/shared";
 
 type Pt = { x: number; y: number };
 
-const W = 16000, H = 9000;
+const W = MAP_W - 1, H = MAP_H - 1;
 let tick = 0;
 
 // Track which of our busters already used RADAR (simple local memory)

--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -12,9 +12,10 @@
  *   - pickFrontierTarget(from: {x,y}): {x,y}
  */
 
+import { MAP_W, MAP_H } from "@busters/shared";
 type Pt = { x: number; y: number };
 
-const W = 16000, H = 9000;
+const W = MAP_W - 1, H = MAP_H - 1;
 const CELL = 400;
 const GX = Math.ceil(W / CELL); // 40
 const GY = Math.ceil(H / CELL); // 23

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -5,6 +5,7 @@ export const meta = { name: "HybridBaseline" };
 import HYBRID_PARAMS, { TUNE as TUNE_IN, WEIGHTS as WEIGHTS_IN } from "./hybrid-params";
 import { Fog } from "./fog";
 import { HybridState, getState } from "./lib/state";
+import { MAP_W, MAP_H } from "@busters/shared";
 import {
   estimateInterceptPoint,
   duelStunDelta,
@@ -20,7 +21,7 @@ const TUNE = TUNE_IN;
 const WEIGHTS = WEIGHTS_IN as any;
 
 /** --- Small utils (no imports) --- */
-const W = 16000, H = 9000;
+const W = MAP_W - 1, H = MAP_H - 1;
 const BUST_MIN = 900, BUST_MAX = 1760;
 const STUN_CD = 20;
 

--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -4,9 +4,11 @@
  *  Keep it tiny and robust; we’ll extend later (ghost probs, priors, etc.).
  */
 
+import { MAP_W as MAP_W_CONST, MAP_H as MAP_H_CONST } from "@busters/shared";
+
 export type Pt = { x: number; y: number };
 
-const MAP_W = 16000, MAP_H = 9000; // safe defaults
+const MAP_W = MAP_W_CONST - 1, MAP_H = MAP_H_CONST - 1; // safe defaults
 function clamp(v: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, v)); }
 function centerOfCell(cx: number, cy: number, cellW: number, cellH: number): Pt {
   return { x: cx * cellW + cellW / 2, y: cy * cellH + cellH / 2 };

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -16,6 +16,9 @@
     "./hybrid-bot": "./hybrid-bot.ts",
     "./hof": "./hof.ts"
   },
+  "dependencies": {
+    "@busters/shared": "workspace:*"
+  },
   "devDependencies": {
     "esbuild": "^0.25.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,10 @@ importers:
         version: 5.9.2
 
   packages/agents:
+    dependencies:
+      '@busters/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       esbuild:
         specifier: ^0.25.9


### PR DESCRIPTION
## Summary
- import `MAP_W` and `MAP_H` from `@busters/shared` in agents
- replace hardcoded map dimensions with shared constants
- add `@busters/shared` as package dependency

## Testing
- `pnpm test`
- `pnpm -F @busters/agents build:cg`
- `pnpm cg:export:hybrid`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf19e830832b8528a008e7c8d9ef