### PR TITLE
Reset fog state at match start

### DIFF
--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -36,6 +36,12 @@ export class Fog {
     for (let i = 0; i < this.last.length; i++) this.last[i] = -1;
   }
 
+  reset() {
+    this.tick = 0;
+    this.last.fill(-1);
+    this.heat.fill(0);
+  }
+
   beginTick(t: number) {
     if (t === this.tick) return;
     this.tick = t;

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -266,6 +266,7 @@ export function act(ctx: Ctx, obs: Obs) {
   const me = obs.self;
   const m = M(me.id);
   const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
+  if (tick <= 1) fog.reset();
   const state = getState(ctx, obs);
   state.trackEnemies(obs.enemies, tick);
 

--- a/packages/sim-runner/src/subjects/hybrid.ts
+++ b/packages/sim-runner/src/subjects/hybrid.ts
@@ -2,6 +2,7 @@
 
 import type { BotModule } from "../types"; // If you don't have this, replace BotModule with: { meta?: any; act: Function }
 import { TUNE as BASE_TUNE, WEIGHTS as BASE_WEIGHTS } from "@busters/agents/hybrid-params";
+import { Fog } from "@busters/agents/fog";
 
 /** The flat param order (19 dims) used by CEM for Hybrid */
 export const ORDER = [
@@ -122,6 +123,7 @@ export function defaultSigmas(): number[] {
 export function makeHybridBotFromTW(tw: TW): BotModule {
   const TUNE = tw.TUNE;
   const WEIGHTS = tw.WEIGHTS;
+  const fog = new Fog();
 
   // --- inline utils
   const W = 16000, H = 9000;
@@ -277,7 +279,8 @@ export function makeHybridBotFromTW(tw: TW): BotModule {
       const me = obs.self;
       const m = M(me.id);
       const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
-
+      if (tick <= 1) fog.reset();
+      
       const { my: MY, enemy: EN } = resolveBases(ctx);
       const enemies = (obs.enemies ?? []).slice().sort((a,b)=> (a.range ?? dist(me.x,me.y,a.x,a.y)) - (b.range ?? dist(me.x,me.y,b.x,b.y)));
       const ghosts  = (obs.ghostsVisible ?? []).slice().sort((a,b)=> (a.range ?? dist(me.x,me.y,a.x,a.y)) - (b.range ?? dist(me.x,me.y,b.x,b.y)));


### PR DESCRIPTION
## Summary
- add `reset()` method to `Fog` to clear grid and tick
- reset fog on new matches in `hybrid-bot.ts`
- reset fog at match start in sim-runner hybrid subject

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4cf2fd86c832baf75697a4a743f88