### PR TITLE
Reset fog state between matches

### DIFF
--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -36,6 +36,12 @@ export class Fog {
     for (let i = 0; i < this.last.length; i++) this.last[i] = -1;
   }
 
+  reset() {
+    this.tick = 0;
+    this.last.fill(-1);
+    this.heat.fill(0);
+  }
+
   beginTick(t: number) {
     if (t === this.tick) return;
     this.tick = t;

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -266,7 +266,7 @@ function runAuction(team: Ent[], tasks: Task[], enemies: Ent[], MY: Pt, tick: nu
 /** --- Main per-buster policy --- */
 export function act(ctx: Ctx, obs: Obs) {
   const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
-  if (tick <= 1 && tick < lastTick) mem.clear();
+  if (tick <= 1 && tick < lastTick) { mem.clear(); fog.reset(); }
   lastTick = tick;
   const me = obs.self;
   const m = M(me.id);

--- a/packages/sim-runner/src/subjects/hybrid.ts
+++ b/packages/sim-runner/src/subjects/hybrid.ts
@@ -2,6 +2,7 @@
 
 import type { BotModule } from "../types"; // If you don't have this, replace BotModule with: { meta?: any; act: Function }
 import { TUNE as BASE_TUNE, WEIGHTS as BASE_WEIGHTS } from "@busters/agents/hybrid-params";
+import { Fog } from "@busters/agents/fog";
 
 /** The flat param order (19 dims) used by CEM for Hybrid */
 export const ORDER = [
@@ -179,6 +180,8 @@ export function makeHybridBotFromTW(tw: TW): BotModule {
 
   const mem = new Map<number, { stunReadyAt: number; radarUsed: boolean }>();
   function M(id: number) { if (!mem.has(id)) mem.set(id, { stunReadyAt: 0, radarUsed: false }); return mem.get(id)!; }
+  const fog = new Fog();
+  let lastTick = Infinity;
 
   function uniqTeam(self: Ent, friends?: Ent[]): Ent[] {
     const map = new Map<number, Ent>();
@@ -277,6 +280,8 @@ export function makeHybridBotFromTW(tw: TW): BotModule {
       const me = obs.self;
       const m = M(me.id);
       const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
+      if (tick <= 1 && tick < lastTick) { mem.clear(); pMem.clear(); planTick = -1; fog.reset(); }
+      lastTick = tick;
 
       const { my: MY, enemy: EN } = resolveBases(ctx);
       const enemies = (obs.enemies ?? []).slice().sort((a,b)=> (a.range ?? dist(me.x,me.y,a.x,a.y)) - (b.range ?? dist(me.x,me.y,b.x,b.y)));


### PR DESCRIPTION
## Summary
- add `Fog.reset()` to clear internal state
- reset fog on match start in `hybrid-bot` and sim-runner's hybrid subject

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d2e9c2d4832ba34995ae22cab96b