### PR TITLE
Limit ejection distance and clamp within map bounds

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -126,3 +126,41 @@ test('attempting BUST while carrying causes ghost escape without scoring', () =>
   assert.equal(escaped.y, b.y);
 });
 
+test('eject moves ghost only up to max distance', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const ghost = state.ghosts[0];
+  state.ghosts = [];
+  b.state = 1;
+  b.value = ghost.id;
+  b.x = 1000;
+  b.y = 1000;
+
+  const targetX = b.x + 500;
+  const targetY = b.y;
+  const actions: ActionsByTeam = { 0: [{ type: 'EJECT', x: targetX, y: targetY }], 1: [] } as any;
+  const next = step(state, actions);
+  assert.equal(next.ghosts.length, 1);
+  const ejected = next.ghosts[0];
+  assert.equal(ejected.x, targetX);
+  assert.equal(ejected.y, targetY);
+});
+
+test('eject clamps ghost position to map bounds', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const ghost = state.ghosts[0];
+  state.ghosts = [];
+  b.state = 1;
+  b.value = ghost.id;
+  b.x = 1000;
+  b.y = 1000;
+
+  const actions: ActionsByTeam = { 0: [{ type: 'EJECT', x: -1000, y: -1000 }], 1: [] } as any;
+  const next = step(state, actions);
+  assert.equal(next.ghosts.length, 1);
+  const ejected = next.ghosts[0];
+  assert.equal(ejected.x, 0);
+  assert.equal(ejected.y, 0);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -86,8 +86,13 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
         case 'RELEASE': intents.set(b.id, a); break;
         case 'RADAR': intents.set(b.id, a); break;
         case 'EJECT': {
-          const dx = a.x - b.x, dy = a.y - b.y; const [nx, ny] = norm(dx, dy);
-          intents.set(b.id, { type: 'EJECT', x: roundi(b.x + nx * RULES.EJECT_MAX), y: roundi(b.y + ny * RULES.EJECT_MAX) });
+          const dx = a.x - b.x, dy = a.y - b.y;
+          const d = Math.hypot(dx, dy);
+          const [nx, ny] = norm(dx, dy);
+          const travel = Math.min(d, RULES.EJECT_MAX);
+          const ex = clamp(roundi(b.x + nx * travel), 0, MAP_W - 1);
+          const ey = clamp(roundi(b.y + ny * travel), 0, MAP_H - 1);
+          intents.set(b.id, { type: 'EJECT', x: ex, y: ey });
           break;
         }
         case 'STUN': intents.set(b.id, a); break;


### PR DESCRIPTION
## Summary
- Adjust EJECT intent to move ghosts only up to the lesser of target distance or RULES.EJECT_MAX and clamp resulting coordinates to the map area
- Add regression tests for short-range ejection and map-bound clamping

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa94aba0832b8c8aab13e9119b1a