### PR TITLE
Preserve busting state across turns

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -126,3 +126,21 @@ test('attempting BUST while carrying causes ghost escape without scoring', () =>
   assert.equal(escaped.y, b.y);
 });
 
+test('buster state=3 persists while busting continuously', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const ghost = state.ghosts[0];
+
+  // Place buster and ghost within bust range and give ghost enough endurance
+  b.x = 1000; b.y = 1000;
+  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 3;
+
+  const actions: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
+
+  const first = step(state, actions);
+  assert.equal(first.busters[0].state, 3);
+
+  const second = step(first, actions);
+  assert.equal(second.busters[0].state, 3);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -48,7 +48,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
   const next: GameState = {
     ...state,
     tick: state.tick + 1,
-    busters: state.busters.map(b => ({ ...b })),
+    busters: state.busters.map(b => ({ ...b, state: b.state === 3 ? 0 : b.state })),
     ghosts: state.ghosts.map(g => ({ ...g, engagedBy: 0 })),
     radarNextVision: {}, // ← will be filled by RADAR uses this tick, to apply on *next* tick
     lastSeenTickForGhost: { ...state.lastSeenTickForGhost }
@@ -298,8 +298,6 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       if (b.value === 0) { b.state = 0; }
     }
     if (b.stunCd > 0) b.stunCd -= 1;
-    // clear "busting" flag if not actually busting next time
-    if (b.state === 3) { b.state = 0; }
   }
 
   return next;


### PR DESCRIPTION
## Summary
- Avoid clearing busting flags in timer processing
- Reset prior bust state when cloning busters each tick
- Add regression test for continuous busting state visibility

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb59eacc832ba0eb3cda83c48865