### PR TITLE
Deduct score for releasing ghosts outside base

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -89,6 +89,30 @@ test('step scores when releasing carried ghost in base', () => {
   assert.equal(bEnd.value, 0);
 });
 
+test('release outside base decrements score', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  // start outside base
+  b.x = TEAM0_BASE.x + RULES.BASE_RADIUS + RULES.BUST_MIN + 10; b.y = TEAM0_BASE.y;
+  const ghost = state.ghosts[0];
+  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+
+  const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
+  const mid = step(state, capture);
+
+  const release: ActionsByTeam = { 0: [{ type: 'RELEASE' }], 1: [] } as any;
+  const end = step(mid, release);
+  const bEnd = end.busters[0];
+  assert.equal(end.scores[0], -1);
+  assert.equal(bEnd.state, 0);
+  assert.equal(bEnd.value, 0);
+  assert.equal(end.ghosts.length, 1);
+  const dropped = end.ghosts[0];
+  assert.equal(dropped.id, ghost.id);
+  assert.equal(dropped.x, b.x);
+  assert.equal(dropped.y, b.y);
+});
+
 test('stun drops carried ghost and sets cooldown', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const attacker = state.busters.find(b => b.teamId === 0)!;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -193,7 +193,8 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
           // (ghost was already removed from map when captured)
           b.state = 0; b.value = 0;
         } else {
-          // drop to ground (no score)
+          // drop to ground (-1 score)
+          next.scores[b.teamId] -= 1;
           const ghost = { id: gid, x: b.x, y: b.y, endurance: 0, engagedBy: 0 };
           next.ghosts.push(ghost);
           ghostById.set(gid, ghost);


### PR DESCRIPTION
## Summary
- Decrement player's score when releasing a carried ghost outside any base, allowing negative scores
- Test release outside base to verify score deduction

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fdb51ebc832b9edc22d095c4beac