### PR TITLE
feat(engine): add entity list output and cg driver

### DIFF
--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process';
+import readline from 'node:readline';
+import { initGame, step } from './engine';
+import { entitiesForTeam } from './perception';
+import { Action, TeamId, MAX_TICKS } from '@busters/shared';
+
+function parseAction(line: string): Action {
+  const parts = line.trim().split(/\s+/);
+  const cmd = parts[0]?.toUpperCase();
+  switch (cmd) {
+    case 'MOVE':
+      return { type: 'MOVE', x: Number(parts[1]), y: Number(parts[2]) };
+    case 'BUST':
+      return { type: 'BUST', ghostId: Number(parts[1]) };
+    case 'RELEASE':
+      return { type: 'RELEASE' };
+    case 'STUN':
+      return { type: 'STUN', busterId: Number(parts[1]) };
+    case 'RADAR':
+      return { type: 'RADAR' };
+    case 'EJECT':
+      return { type: 'EJECT', x: Number(parts[1]), y: Number(parts[2]) };
+    default:
+      return { type: 'MOVE', x: 0, y: 0 };
+  }
+}
+
+async function readLines(rl: readline.Interface, count: number): Promise<string[]> {
+  return new Promise(resolve => {
+    const lines: string[] = [];
+    const onLine = (line: string) => {
+      lines.push(line.trim());
+      if (lines.length === count) {
+        rl.removeListener('line', onLine);
+        resolve(lines);
+      }
+    };
+    rl.on('line', onLine);
+  });
+}
+
+async function main() {
+  const [bot0Cmd, bot1Cmd] = process.argv.slice(2);
+  if (!bot0Cmd || !bot1Cmd) {
+    console.error('Usage: node cg-driver.js <bot0> <bot1>');
+    process.exit(1);
+  }
+
+  const bots = [
+    spawn(bot0Cmd, { stdio: ['pipe', 'pipe', 'inherit'], shell: true }),
+    spawn(bot1Cmd, { stdio: ['pipe', 'pipe', 'inherit'], shell: true })
+  ];
+  const readers = bots.map(b => readline.createInterface({ input: b.stdout }));
+
+  let state = initGame({ seed: 1, bustersPerPlayer: 2, ghostCount: 4 });
+
+  for (const t of [0, 1] as TeamId[]) {
+    const w = bots[t].stdin;
+    w.write(`${state.bustersPerPlayer}\n`);
+    w.write(`${state.ghostCount}\n`);
+    w.write(`${t}\n`);
+  }
+
+  while (state.tick < MAX_TICKS) {
+    for (const t of [0, 1] as TeamId[]) {
+      const entities = entitiesForTeam(state, t);
+      const w = bots[t].stdin;
+      w.write(`${entities.length}\n`);
+      for (const e of entities) {
+        w.write(`${e.id} ${e.x} ${e.y} ${e.entityType} ${e.state} ${e.value}\n`);
+      }
+    }
+
+    const [lines0, lines1] = await Promise.all([
+      readLines(readers[0], state.bustersPerPlayer),
+      readLines(readers[1], state.bustersPerPlayer)
+    ]);
+
+    const actions: Record<TeamId, Action[]> = {
+      0: lines0.map(parseAction),
+      1: lines1.map(parseAction)
+    } as any;
+
+    state = step(state, actions);
+  }
+
+  console.log(`Final scores: ${state.scores[0]} - ${state.scores[1]}`);
+  bots.forEach(b => b.kill());
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/engine/src/perception.test.ts
+++ b/packages/engine/src/perception.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { initGame } from './engine';
-import { observationsForTeam } from './perception';
+import { observationsForTeam, entitiesForTeam } from './perception';
 import { RULES } from '@busters/shared';
 
 test('radar vision reveals distant entities', () => {
@@ -24,4 +24,27 @@ test('radar vision reveals distant entities', () => {
   assert.equal(obs.ghostsVisible[0].id, ghost.id);
   assert.equal(obs.enemies.length, 1);
   assert.equal(obs.enemies[0].id, enemy.id);
+});
+
+test('entity list includes radar-detected units', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const me = state.busters.find(b => b.teamId === 0)!;
+  const enemy = state.busters.find(b => b.teamId === 1)!;
+  const ghost = state.ghosts[0];
+
+  me.x = 0; me.y = 0;
+  enemy.x = RULES.VISION + 100; enemy.y = 0;
+  ghost.x = RULES.VISION + 100; ghost.y = 0;
+
+  let list = entitiesForTeam(state, 0);
+  // only own buster visible
+  assert.equal(list.length, 1);
+
+  state.radarNextVision[me.id] = true;
+  list = entitiesForTeam(state, 0);
+  const ids = list.map(e => e.id);
+  assert.equal(list.length, 3);
+  assert(ids.includes(me.id));
+  assert(ids.includes(enemy.id));
+  assert(ids.includes(ghost.id));
 });


### PR DESCRIPTION
## Summary
- add `entitiesForTeam` to produce CodinGame-style entity lists
- test radar visibility for new entity output
- add `cg-driver` script to run external `readline`/`console.log` bots

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fddf9944832b8051370ca4e46f7b