### PR TITLE
Fix ghost flee timing

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -211,3 +211,24 @@ test('eject clamps ghost position to map bounds', () => {
   assert.equal(ejected.y, 0);
 });
 
+test('ghost begins fleeing one turn after detection', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const g = state.ghosts[0];
+  g.x = 5000;
+  g.y = 5000;
+  b.x = g.x;
+  b.y = g.y + RULES.VISION + 100;
+
+  const approach: ActionsByTeam = { 0: [{ type: 'MOVE', x: g.x, y: g.y }], 1: [] } as any;
+  const mid = step(state, approach);
+  const gMid = mid.ghosts[0];
+  assert.equal(gMid.x, g.x);
+  assert.equal(gMid.y, g.y);
+
+  const end = step(mid, { 0: [], 1: [] } as any);
+  const gEnd = end.ghosts[0];
+  assert.equal(gEnd.x, g.x);
+  assert.equal(gEnd.y, g.y - RULES.GHOST_FLEE);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -314,7 +314,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       g.x = clamp(roundi(g.x + nx * RULES.GHOST_FLEE), 0, next.width - 1);
       g.y = clamp(roundi(g.y + ny * RULES.GHOST_FLEE), 0, next.height - 1);
     }
-    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = next.tick;
+    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = state.tick;
   }
 
   // 8) Timers


### PR DESCRIPTION
## Summary
- fix ghost detection recording to use current tick so ghosts flee immediately next turn
- add regression test verifying ghosts flee one turn after entering vision

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe16b31c832b92007d201339c0e2