### PR TITLE
Start stun cooldown on any attempt

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -119,6 +119,24 @@ test('stun drops carried ghost and sets cooldown', () => {
   assert.equal(next.ghosts[0].y, victim.y);
 });
 
+test('out-of-range STUN still consumes cooldown', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
+  const attacker = state.busters.find(b => b.teamId === 0)!;
+  const victim = state.busters.find(b => b.teamId === 1)!;
+
+  attacker.x = 1000; attacker.y = 1000;
+  victim.x = attacker.x + RULES.STUN_RANGE + 1; victim.y = attacker.y;
+
+  const actions: ActionsByTeam = { 0: [{ type: 'STUN', busterId: victim.id }], 1: [] } as any;
+  const next = step(state, actions);
+
+  const postAttacker = next.busters.find(b => b.id === attacker.id)!;
+  assert.equal(postAttacker.stunCd, RULES.STUN_COOLDOWN - 1);
+
+  const postVictim = next.busters.find(b => b.id === victim.id)!;
+  assert.equal(postVictim.state, 0);
+});
+
 test('re-stunning resets stun timer to full duration', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 2, ghostCount: 0 });
   const [attacker1, attacker2] = state.busters.filter(b => b.teamId === 0);

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -155,21 +155,22 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
   // 3) STUN resolution (resets stun duration; both drop any carried ghost)
   for (const b of next.busters) {
     const a = intents.get(b.id);
-    if (a?.type === 'STUN' && b.stunCd <= 0) {
-      const target = busterById.get(a.busterId);
-      if (target && target.teamId !== b.teamId) {
-        const d = dist(b.x, b.y, target.x, target.y);
-        if (d <= RULES.STUN_RANGE) {
-          // Always reset stun timer to full duration
-          target.state = 2;
-          target.value = RULES.STUN_DURATION;
+    if (a?.type === 'STUN') {
+      if (b.stunCd <= 0) {
+        // cooldown starts regardless of success
+        b.stunCd = RULES.STUN_COOLDOWN;
+        const target = busterById.get(a.busterId);
+        if (target && target.teamId !== b.teamId) {
+          const d = dist(b.x, b.y, target.x, target.y);
+          if (d <= RULES.STUN_RANGE) {
+            // Always reset stun timer to full duration
+            target.state = 2;
+            target.value = RULES.STUN_DURATION;
 
-          // Both sides drop what they were carrying (start-of-tick)
-          dropCarried(target, startCarry.get(target.id) ?? null);
-          dropCarried(b,      startCarry.get(b.id)      ?? null);
-
-          // cooldown
-          b.stunCd = RULES.STUN_COOLDOWN;
+            // Both sides drop what they were carrying (start-of-tick)
+            dropCarried(target, startCarry.get(target.id) ?? null);
+            dropCarried(b,      startCarry.get(b.id)      ?? null);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Trigger STUN cooldown whenever a buster issues STUN, even if the target is invalid or out of range
- Add regression test verifying out-of-range STUN still starts cooldown

## Testing
- `pnpm test`
- `cd packages/engine && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe1ad360832bb5f48385ded8ebaf