### PR TITLE
Reset bust target on timer

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -211,3 +211,19 @@ test('eject clamps ghost position to map bounds', () => {
   assert.equal(ejected.y, 0);
 });
 
+test('buster value resets after busting without capture', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const g = state.ghosts[0];
+  b.x = 1000; b.y = 1000;
+  g.x = b.x + RULES.BUST_MIN; g.y = b.y; g.endurance = 2;
+
+  const bust: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: g.id }], 1: [] } as any;
+  const mid = step(state, bust);
+
+  const end = step(mid, { 0: [], 1: [] } as any);
+  const bEnd = end.busters[0];
+  assert.equal(bEnd.state, 0);
+  assert.equal(bEnd.value, 0);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -324,8 +324,8 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       if (b.value === 0) { b.state = 0; }
     }
     if (b.stunCd > 0) b.stunCd -= 1;
-    // clear "busting" flag if not actually busting next time
-    if (b.state === 3) { b.state = 0; }
+    // clear "busting" flag and any target if not actually busting next time
+    if (b.state === 3) { b.state = 0; b.value = 0; }
   }
 
   return next;


### PR DESCRIPTION
## Summary
- Clear busting state and target in timer loop
- Add regression test verifying bust value resets to 0

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe30e33c832b82a99752a92ac7c6