### PR TITLE
Add game over state tracking for ticks and ghosts

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -1,12 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { initGame, step, ActionsByTeam } from './engine';
-import { MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE, RULES } from '@busters/shared';
+import { MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE, RULES, MAX_TICKS } from '@busters/shared';
 
 test('initGame sets up teams and ghosts within bounds', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 2, ghostCount: 3 });
   assert.equal(state.busters.length, 4);
   assert.equal(state.ghosts.length, 3);
+  assert.equal(state.remainingGhosts, state.ghostCount);
+  assert.equal(state.gameOver, false);
 
   for (const b of state.busters) {
     if (b.teamId === 0) {
@@ -87,6 +89,8 @@ test('step scores when releasing carried ghost in base', () => {
   assert.equal(end.scores[0], 1);
   assert.equal(bEnd.state, 0);
   assert.equal(bEnd.value, 0);
+  assert.equal(end.remainingGhosts, 0);
+  assert.equal(end.gameOver, true);
 });
 
 test('stun drops carried ghost and sets cooldown', () => {
@@ -209,5 +213,13 @@ test('eject clamps ghost position to map bounds', () => {
   const ejected = next.ghosts[0];
   assert.equal(ejected.x, 0);
   assert.equal(ejected.y, 0);
+});
+
+test('gameOver becomes true when max ticks reached', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  state.tick = MAX_TICKS - 1;
+  const next = step(state, { 0: [], 1: [] } as any);
+  assert.equal(next.tick, MAX_TICKS);
+  assert.equal(next.gameOver, true);
 });
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,5 +1,5 @@
 import { Action, GameState, TeamId, GhostState, BusterPublicState } from '@busters/shared';
-import { RULES, MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
+import { RULES, MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE, MAX_TICKS } from '@busters/shared';
 import { clamp, dist, dist2, norm, roundi } from '@busters/shared';
 
 const BUSTER_OFFSETS: { x: number; y: number }[] = [
@@ -52,10 +52,12 @@ export function initGame({ seed = 1, bustersPerPlayer, ghostCount, endurancePool
   const state: GameState = {
     seed, tick: 0, width: MAP_W, height: MAP_H,
     bustersPerPlayer, ghostCount,
+    remainingGhosts: ghostCount,
     scores: { 0: 0, 1: 0 },
     busters, ghosts,
     radarNextVision: {},                 // used by next tick only
-    lastSeenTickForGhost: {}
+    lastSeenTickForGhost: {},
+    gameOver: false
   };
   return state;
 }
@@ -327,6 +329,10 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
     // clear "busting" flag if not actually busting next time
     if (b.state === 3) { b.state = 0; }
   }
+
+  const scored = next.scores[0] + next.scores[1];
+  next.remainingGhosts = next.ghostCount - scored;
+  next.gameOver = next.tick >= MAX_TICKS || scored === next.ghostCount;
 
   return next;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -35,11 +35,13 @@ export type GameState = {
   height: number;
   bustersPerPlayer: number;
   ghostCount: number;
+  remainingGhosts: number;
   scores: Record<TeamId, number>;
   busters: BusterPublicState[]; // both teams
   ghosts: GhostState[]; // ghosts still on map (not scored)
   radarNextVision: Record<number, boolean>; // busterId -> true if radar effect active for next turn
   lastSeenTickForGhost: Record<number, number>; // ghostId -> last tick any buster detected (for flee timing)
+  gameOver: boolean;
 };
 
 export type Observation = {

--- a/packages/sim-runner/src/runEpisodes.ts
+++ b/packages/sim-runner/src/runEpisodes.ts
@@ -62,7 +62,7 @@ export async function runEpisodes(opts: RunOpts) {
 
       opts.onTick?.(state);
 
-      if (state.tick >= 250 || state.ghosts.length === 0) break;
+      if (state.gameOver) break;
     }
 
     totalScoreA += state.scores[0];


### PR DESCRIPTION
## Summary
- track remainingGhosts and gameOver in GameState
- end engine step when max ticks reached or all ghosts scored
- stop sim runner when gameOver flag is true

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe34ab0c832badf59e0fc08137fb