### PR TITLE
Handle wait commands as no-ops

### DIFF
--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process';
 import readline from 'node:readline';
-import { initGame, step } from './engine';
+import { initGame, step, ActionsByTeam } from './engine';
 import { entitiesForTeam } from './perception';
 import { Action, TeamId, MAX_TICKS } from '@busters/shared';
 
-function parseAction(line: string): Action {
+function parseAction(line: string): Action | undefined {
   const parts = line.trim().split(/\s+/);
   const cmd = parts[0]?.toUpperCase();
   switch (cmd) {
@@ -20,8 +20,10 @@ function parseAction(line: string): Action {
       return { type: 'RADAR' };
     case 'EJECT':
       return { type: 'EJECT', x: Number(parts[1]), y: Number(parts[2]) };
+    case 'WAIT':
+      return undefined;
     default:
-      return { type: 'MOVE', x: 0, y: 0 };
+      return undefined;
   }
 }
 
@@ -76,10 +78,10 @@ async function main() {
       readLines(readers[1], state.bustersPerPlayer)
     ]);
 
-    const actions: Record<TeamId, Action[]> = {
+    const actions: ActionsByTeam = {
       0: lines0.map(parseAction),
       1: lines1.map(parseAction)
-    } as any;
+    };
 
     state = step(state, actions);
   }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -58,7 +58,7 @@ function withinBase(b: {x:number;y:number}): { team: TeamId | null } {
   return { team: (base0 ?? base1) as TeamId | null };
 }
 
-export type ActionsByTeam = Record<TeamId, Action[]>; // index aligned with each team's busters order
+export type ActionsByTeam = Record<TeamId, (Action | undefined)[]>; // index aligned with each team's busters order
 
 export function step(state: GameState, actions: ActionsByTeam): GameState {
   // NOTE: radarNextVision is not carried over; it is *consumed* by perception for this tick only


### PR DESCRIPTION
## Summary
- allow actions arrays to include `undefined` so the engine skips missing intents
- treat `WAIT` or unknown commands as no-ops in the Codingame driver

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a601fd0684832b8a4c9cfd9ef36aec