### PR TITLE
feat(engine): persist bust state across turns

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -284,3 +284,20 @@ test('stunned buster cannot use RADAR', () => {
   assert.ok(!(victim.id in next.radarNextVision));
 });
 
+test('busting state persists into next turn until another action', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const ghost = state.ghosts[0];
+  b.x = 1000; b.y = 1000;
+  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 2;
+
+  const bust: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
+  const mid = step(state, bust);
+  const bMid = mid.busters[0];
+  assert.equal(bMid.state, 3);
+
+  const end = step(mid, { 0: [], 1: [] } as any);
+  const bEnd = end.busters[0];
+  assert.equal(bEnd.state, 0);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -71,6 +71,14 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
     lastSeenTickForGhost: { ...state.lastSeenTickForGhost }
   };
 
+  // Clear previous "busting" flags from last turn
+  for (const b of next.busters) {
+    if (b.state === 3) {
+      b.state = 0;
+      b.value = 0;
+    }
+  }
+
   const busterById = new Map<number, BusterPublicState>();
   next.busters.forEach(b => busterById.set(b.id, b));
   const ghostById = new Map<number, GhostState>();
@@ -324,8 +332,6 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       if (b.value === 0) { b.state = 0; }
     }
     if (b.stunCd > 0) b.stunCd -= 1;
-    // clear "busting" flag if not actually busting next time
-    if (b.state === 3) { b.state = 0; }
   }
 
   return next;


### PR DESCRIPTION
## Summary
- ensure busters clear old busting flags at step start
- drop end-of-turn bust state reset to expose ongoing busting
- test bust state persistence across turns

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60201f780832b8f5417144362cc31