### PR TITLE
Allow ghosts to spawn at edges and match pair endurance

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -19,8 +19,8 @@ test('initGame sets up teams and ghosts within bounds', () => {
   }
 
   for (const g of state.ghosts) {
-    assert.ok(g.x >= 500 && g.x <= MAP_W - 500);
-    assert.ok(g.y >= 500 && g.y <= MAP_H - 500);
+    assert.ok(g.x >= 0 && g.x < MAP_W);
+    assert.ok(g.y >= 0 && g.y < MAP_H);
   }
 });
 
@@ -41,6 +41,7 @@ test('initGame places busters and ghosts symmetrically', () => {
     const g1 = state.ghosts[i + 1];
     assert.equal(g0.x + g1.x, MAP_W - 1);
     assert.equal(g0.y + g1.y, MAP_H - 1);
+    assert.equal(g0.endurance, g1.endurance);
   }
 });
 
@@ -49,8 +50,8 @@ test('odd ghost placement depends on seed', () => {
   const s2 = initGame({ seed: 2, bustersPerPlayer: 1, ghostCount: 1 });
   const g1 = s1.ghosts[0];
   const g2 = s2.ghosts[0];
-  assert.ok(g1.x >= 500 && g1.x <= MAP_W - 500);
-  assert.ok(g1.y >= 500 && g1.y <= MAP_H - 500);
+  assert.ok(g1.x >= 0 && g1.x < MAP_W);
+  assert.ok(g1.y >= 0 && g1.y < MAP_H);
   assert.ok(g1.x !== g2.x || g1.y !== g2.y);
 });
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -19,20 +19,19 @@ export function initGame({ seed = 1, bustersPerPlayer, ghostCount, endurancePool
   const rng = new XorShift32(seed);
   const pairCount = Math.floor(ghostCount / 2);
   const randCoord = () => ({
-    x: 500 + Math.floor(rng.float() * (MAP_W - 1000)),
-    y: 500 + Math.floor(rng.float() * (MAP_H - 1000)),
+    x: Math.floor(rng.float() * MAP_W),
+    y: Math.floor(rng.float() * MAP_H),
   });
   const randEndurance = () => endurancePool[Math.floor(rng.float() * endurancePool.length)];
   for (let i = 0; i < pairCount; i++) {
     const { x: gx, y: gy } = randCoord();
-    const enduranceA = randEndurance();
-    const enduranceB = randEndurance();
-    ghosts.push({ id: ghosts.length, x: gx, y: gy, endurance: enduranceA, engagedBy: 0 });
+    const endurance = randEndurance();
+    ghosts.push({ id: ghosts.length, x: gx, y: gy, endurance, engagedBy: 0 });
     ghosts.push({
       id: ghosts.length,
       x: MAP_W - 1 - gx,
       y: MAP_H - 1 - gy,
-      endurance: enduranceB,
+      endurance,
       engagedBy: 0,
     });
   }


### PR DESCRIPTION
## Summary
- expand ghost spawn range to full map by removing margin in `randCoord`
- give paired ghosts identical endurance values
- update engine tests for new spawn range and endurance pairing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60204afbc832bb1b14fbf3938c9ca