### PR TITLE
Stop driver after ghosts captured

### DIFF
--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldContinue } from './cg-driver';
+import { GameState } from '@busters/shared';
+
+test('shouldContinue returns false when no ghosts and no buster carrying', () => {
+  const state: GameState = {
+    seed: 1,
+    tick: 0,
+    width: 0,
+    height: 0,
+    bustersPerPlayer: 1,
+    ghostCount: 0,
+    scores: { 0: 0, 1: 0 },
+    busters: [{ id: 0, teamId: 0, x: 0, y: 0, state: 0, value: 0, stunCd: 0, radarUsed: false }],
+    ghosts: [],
+    radarNextVision: {},
+    lastSeenTickForGhost: {}
+  };
+  assert.equal(shouldContinue(state), false);
+});
+
+test('shouldContinue returns true when ghosts remain', () => {
+  const state: GameState = {
+    seed: 1,
+    tick: 0,
+    width: 0,
+    height: 0,
+    bustersPerPlayer: 1,
+    ghostCount: 1,
+    scores: { 0: 0, 1: 0 },
+    busters: [{ id: 0, teamId: 0, x: 0, y: 0, state: 0, value: 0, stunCd: 0, radarUsed: false }],
+    ghosts: [{ id: 0, x: 0, y: 0, endurance: 0, engagedBy: 0 }],
+    radarNextVision: {},
+    lastSeenTickForGhost: {}
+  };
+  assert.equal(shouldContinue(state), true);
+});
+
+test('shouldContinue returns true when a buster is carrying', () => {
+  const state: GameState = {
+    seed: 1,
+    tick: 0,
+    width: 0,
+    height: 0,
+    bustersPerPlayer: 1,
+    ghostCount: 0,
+    scores: { 0: 0, 1: 0 },
+    busters: [{ id: 0, teamId: 0, x: 0, y: 0, state: 1, value: 0, stunCd: 0, radarUsed: false }],
+    ghosts: [],
+    radarNextVision: {},
+    lastSeenTickForGhost: {}
+  };
+  assert.equal(shouldContinue(state), true);
+});


### PR DESCRIPTION
## Summary
- exit CG driver once all ghosts removed and no busters carry
- add unit tests for new termination logic

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6020d3e70832b995b2df0ce9e9225