### PR TITLE
Handle invalid commands in CodinGame driver

### DIFF
--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -21,7 +21,9 @@ function parseAction(line: string): Action {
     case 'EJECT':
       return { type: 'EJECT', x: Number(parts[1]), y: Number(parts[2]) };
     default:
-      return { type: 'MOVE', x: 0, y: 0 };
+      const err = new Error(`Invalid command: ${line}`);
+      console.error(err.message);
+      throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- Throw an error when cg-driver parses an unknown command
- Log the offending line to aid debugging of invalid bot output

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6022060b0832b9116c5de61b2c9b5