### PR TITLE
Handle mutual stuns simultaneously

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -284,3 +284,39 @@ test('stunned buster cannot use RADAR', () => {
   assert.ok(!(victim.id in next.radarNextVision));
 });
 
+test('mutual stuns affect both busters and drop carried ghosts', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 2 });
+  const b0 = state.busters.find(b => b.teamId === 0)!;
+  const b1 = state.busters.find(b => b.teamId === 1)!;
+  const [g0, g1] = state.ghosts;
+  state.ghosts = [];
+  b0.state = 1; b0.value = g0.id;
+  b1.state = 1; b1.value = g1.id;
+  b0.x = 5000; b0.y = 5000;
+  b1.x = b0.x + RULES.STUN_RANGE - 1; b1.y = b0.y;
+
+  const actions: ActionsByTeam = {
+    0: [{ type: 'STUN', busterId: b1.id }],
+    1: [{ type: 'STUN', busterId: b0.id }],
+  } as any;
+
+  const next = step(state, actions);
+  const nb0 = next.busters.find(b => b.id === b0.id)!;
+  const nb1 = next.busters.find(b => b.id === b1.id)!;
+
+  assert.equal(nb0.state, 2);
+  assert.equal(nb1.state, 2);
+  assert.equal(nb0.value, RULES.STUN_DURATION - 1);
+  assert.equal(nb1.value, RULES.STUN_DURATION - 1);
+  assert.equal(nb0.stunCd, RULES.STUN_COOLDOWN - 1);
+  assert.equal(nb1.stunCd, RULES.STUN_COOLDOWN - 1);
+
+  assert.equal(next.ghosts.length, 2);
+  const dg0 = next.ghosts.find(g => g.id === g0.id)!;
+  const dg1 = next.ghosts.find(g => g.id === g1.id)!;
+  assert.equal(dg0.x, b0.x);
+  assert.equal(dg0.y, b0.y);
+  assert.equal(dg1.x, b1.x);
+  assert.equal(dg1.y, b1.y);
+});
+


### PR DESCRIPTION
## Summary
- collect all valid stun intents before applying effects
- apply stun effects to all targets in a single pass so cross-stuns take effect
- test mutual stun handling and ghost drops

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6022a466c832bb13ba91fd6a455d2