### PR TITLE
Fix ghost flee detection tick and add flee test

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -284,3 +284,25 @@ test('stunned buster cannot use RADAR', () => {
   assert.ok(!(victim.id in next.radarNextVision));
 });
 
+test('ghost flees 400 units after being seen', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  const g = state.ghosts[0];
+
+  // place buster within vision range of the ghost
+  b.x = 6000; b.y = 5000;
+  g.x = 5000; g.y = 5000;
+
+  // first step: ghost is seen but does not flee yet
+  const mid = step(state, { 0: [], 1: [] } as any);
+  const gSeen = mid.ghosts[0];
+  assert.equal(gSeen.x, 5000);
+  assert.equal(gSeen.y, 5000);
+
+  // second step: ghost should move 400 units away from the buster
+  const end = step(mid, { 0: [], 1: [] } as any);
+  const gFled = end.ghosts[0];
+  assert.equal(gFled.x, gSeen.x - RULES.GHOST_FLEE);
+  assert.equal(gFled.y, gSeen.y);
+});
+

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -314,7 +314,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       g.x = clamp(roundi(g.x + nx * RULES.GHOST_FLEE), 0, next.width - 1);
       g.y = clamp(roundi(g.y + ny * RULES.GHOST_FLEE), 0, next.height - 1);
     }
-    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = next.tick;
+    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = state.tick;
   }
 
   // 8) Timers


### PR DESCRIPTION
## Summary
- record ghost detection tick using state.tick so ghosts flee on the following turn
- add unit test verifying a ghost flees 400 units after being seen

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6023d9264832ba7d71bb98eaf50fe