### PR TITLE
Fix ghost flee tracking

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -320,7 +320,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       g.x = clamp(roundi(g.x + nx * RULES.GHOST_FLEE), 0, next.width - 1);
       g.y = clamp(roundi(g.y + ny * RULES.GHOST_FLEE), 0, next.height - 1);
     }
-    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = next.tick;
+    if (detectedNow.has(g.id)) next.lastSeenTickForGhost[g.id] = state.tick;
   }
 
   // 8) Timers


### PR DESCRIPTION
## Summary
- record ghost's last-seen tick using current state when fleeing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6049331e0832bb81795e48a116300