### PR TITLE
Sort entities globally by id

### DIFF
--- a/packages/engine/src/perception.test.ts
+++ b/packages/engine/src/perception.test.ts
@@ -48,3 +48,21 @@ test('entity list includes radar-detected units', () => {
   assert(ids.includes(enemy.id));
   assert(ids.includes(ghost.id));
 });
+
+test('entities are returned sorted by id', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const me = state.busters.find(b => b.teamId === 0)!;
+  const enemy = state.busters.find(b => b.teamId === 1)!;
+  const ghost = state.ghosts[0];
+
+  // Place all entities within vision so they appear in the list
+  me.x = 0; me.y = 0;
+  enemy.x = 0; enemy.y = 0;
+  ghost.x = 0; ghost.y = 0;
+
+  const list = entitiesForTeam(state, 0);
+  assert.equal(list.length, 3);
+  const ids = list.map(e => e.id);
+  const sorted = [...ids].sort((a, b) => a - b);
+  assert.deepEqual(ids, sorted);
+});

--- a/packages/engine/src/perception.ts
+++ b/packages/engine/src/perception.ts
@@ -90,22 +90,17 @@ export function entitiesForTeam(state: GameState, teamId: TeamId): EntityView[] 
     }
   }
 
-  const res: EntityView[] = [];
-  // Add own busters first (sorted by id for stability)
-  const ownSorted = my
-    .map(b => ({
-      id: b.id,
-      x: b.x,
-      y: b.y,
-      entityType: teamId,
-      state: b.state,
-      value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : b.stunCd
-    }))
-    .sort((a, b) => a.id - b.id);
-  res.push(...ownSorted);
+  // Collect all entities then sort globally by id to mirror CodinGame ordering
+  const own = my.map(b => ({
+    id: b.id,
+    x: b.x,
+    y: b.y,
+    entityType: teamId,
+    state: b.state,
+    value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : b.stunCd
+  }));
 
-  // Visible enemies
-  const enemiesSorted = Array.from(visibleEnemies.values())
+  const enemies = Array.from(visibleEnemies.values())
     .filter(b => b.teamId !== teamId)
     .map(b => ({
       id: b.id,
@@ -114,22 +109,18 @@ export function entitiesForTeam(state: GameState, teamId: TeamId): EntityView[] 
       entityType: b.teamId,
       state: b.state,
       value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : b.stunCd
-    }))
-    .sort((a, b) => a.id - b.id);
-  res.push(...enemiesSorted);
+    }));
 
-  // Visible ghosts
-  const ghostsSorted = Array.from(visibleGhosts.values())
-    .map(g => ({
-      id: g.id,
-      x: g.x,
-      y: g.y,
-      entityType: -1,
-      state: g.endurance,
-      value: g.engagedBy
-    }))
-    .sort((a, b) => a.id - b.id);
-  res.push(...ghostsSorted);
+  const ghosts = Array.from(visibleGhosts.values()).map(g => ({
+    id: g.id,
+    x: g.x,
+    y: g.y,
+    entityType: -1,
+    state: g.endurance,
+    value: g.engagedBy
+  }));
 
+  const res: EntityView[] = [...own, ...enemies, ...ghosts];
+  res.sort((a, b) => a.id - b.id);
   return res;
 }


### PR DESCRIPTION
## Summary
- Combine own busters, visible enemies and ghosts into a single entity list
- Sort the combined list by `id` to match CodinGame ordering
- Add unit test validating entity list sorting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60937b238832b949ee28d79e359b9