### PR TITLE
feat: use CodinGame RNG

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,6 +1,6 @@
 import { Action, GameState, TeamId, GhostState, BusterPublicState } from '@busters/shared';
 import { RULES, MAP_W, MAP_H, TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
-import { clamp, dist, dist2, norm, roundi, XorShift32 } from '@busters/shared';
+import { clamp, dist, dist2, norm, roundi, CodinGameRandom } from '@busters/shared';
 
 export type InitOpts = { seed?: number; bustersPerPlayer: number; ghostCount: number; endurancePool?: number[] };
 
@@ -16,13 +16,13 @@ export function initGame({ seed = 1, bustersPerPlayer, ghostCount, endurancePool
     }
   }
   const ghosts: GhostState[] = [];
-  const rng = new XorShift32(seed);
+  const rng = new CodinGameRandom(seed);
   const pairCount = Math.floor(ghostCount / 2);
   const randCoord = () => ({
-    x: Math.floor(rng.float() * MAP_W),
-    y: Math.floor(rng.float() * MAP_H),
+    x: rng.intBetween(MAP_W),
+    y: rng.intBetween(MAP_H),
   });
-  const randEndurance = () => endurancePool[Math.floor(rng.float() * endurancePool.length)];
+  const randEndurance = () => endurancePool[rng.intBetween(endurancePool.length)];
   for (let i = 0; i < pairCount; i++) {
     const { x: gx, y: gy } = randCoord();
     const endurance = randEndurance();

--- a/packages/shared/src/rng.test.ts
+++ b/packages/shared/src/rng.test.ts
@@ -1,24 +1,24 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { XorShift32 } from './rng';
+import { CodinGameRandom } from './rng';
 
-test('XorShift32 generates a deterministic sequence', () => {
-  const rng = new XorShift32(1);
-  assert.equal(rng.int(), 270369);
-  assert.equal(rng.int(), 67634689);
+test('CodinGameRandom generates a deterministic sequence', () => {
+  const rng = new CodinGameRandom(1);
+  assert.equal(rng.int(), 3139097971);
+  assert.equal(rng.int(), 431529176);
 });
 
-test('XorShift32 float output is within [0, 1) and never equals 1', () => {
-  const rng = new XorShift32(123);
-  for (let i = 0; i < 1_000_000; i++) {
-    const v = rng.float();
-    assert.ok(v >= 0 && v < 1);
-  }
-});
-
-test('XorShift32 float handles max int without returning 1', () => {
-  // Seed computed to make the first int() call return 0xFFFFFFFF
-  const rng = new XorShift32(1584200935);
+test('CodinGameRandom float output is within [0, 1) and matches known value', () => {
+  const rng = new CodinGameRandom(1);
   const v = rng.float();
-  assert.ok(v < 1);
+  assert.ok(v >= 0 && v < 1);
+  assert.equal(v, 0.7308781907032909);
+});
+
+test('CodinGameRandom intBetween stays within bounds', () => {
+  const rng = new CodinGameRandom(123);
+  for (let i = 0; i < 1000; i++) {
+    const v = rng.intBetween(5);
+    assert.ok(v >= 0 && v < 5);
+  }
 });

--- a/packages/shared/src/rng.ts
+++ b/packages/shared/src/rng.ts
@@ -1,14 +1,49 @@
-export class XorShift32 {
-  private _state: number;
+export class CodinGameRandom {
+  private seed: bigint;
+  private static readonly MULTIPLIER = 0x5DEECE66Dn;
+  private static readonly ADDEND = 0xBn;
+  private static readonly MASK = (1n << 48n) - 1n;
+
   constructor(seed = 1) {
-    this._state = seed >>> 0 || 1;
+    this.seed = (BigInt(seed) ^ CodinGameRandom.MULTIPLIER) & CodinGameRandom.MASK;
   }
+
+  private next(bits: number): bigint {
+    this.seed = (this.seed * CodinGameRandom.MULTIPLIER + CodinGameRandom.ADDEND) & CodinGameRandom.MASK;
+    return this.seed >> (48n - BigInt(bits));
+  }
+
+  /**
+   * Returns a pseudo-random 32-bit integer.
+   */
   int(): number {
-    // https://en.wikipedia.org/wiki/Xorshift
-    let x = this._state;
-    x ^= x << 13; x ^= x >>> 17; x ^= x << 5;
-    this._state = x >>> 0;
-    return this._state;
+    return Number(this.next(32));
   }
-  float(): number { return (this.int() >>> 0) / 0x100000000; }
+
+  /**
+   * Returns a uniform integer in [0, bound).
+   */
+  intBetween(bound: number): number {
+    if (bound <= 0) throw new Error('bound must be positive');
+    const b = BigInt(bound);
+    if ((bound & (bound - 1)) === 0) {
+      return Number((b * this.next(31)) >> 31n);
+    }
+    let bits: bigint, val: bigint;
+    do {
+      bits = this.next(31);
+      val = bits % b;
+    } while (bits - val + (b - 1n) < 0n);
+    return Number(val);
+  }
+
+  /**
+   * Returns a floating point number in [0, 1).
+   */
+  float(): number {
+    const high = this.next(26);
+    const low = this.next(27);
+    const result = (high << 27n) + low;
+    return Number(result) / 2 ** 53;
+  }
 }

--- a/packages/sim-runner/src/runEpisodes.ts
+++ b/packages/sim-runner/src/runEpisodes.ts
@@ -2,7 +2,7 @@ import { initGame, step } from '@busters/engine';
 import { observationsForTeam } from '@busters/engine';
 import { TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
 import type { Action, AgentContext } from '@busters/shared';
-import { XorShift32 } from '@busters/shared';
+import { CodinGameRandom } from '@busters/shared';
 
 type DebugEvent = {
   side: 'A' | 'B';
@@ -25,7 +25,7 @@ export interface RunOpts {
    * Optional sampler to vary params per episode while keeping determinism.
    * If provided, it overrides bustersPerPlayer/ghostCount/seed for that episode.
    */
-  sampler?: (epIndex: number, rng: XorShift32) => {
+  sampler?: (epIndex: number, rng: CodinGameRandom) => {
     bustersPerPlayer: number;
     ghostCount: number;
     seedOffset?: number; // added to base seed to create the episode seed
@@ -34,7 +34,7 @@ export interface RunOpts {
 
 export async function runEpisodes(opts: RunOpts) {
   let totalScoreA = 0, totalScoreB = 0;
-  const masterRng = new XorShift32(opts.seed ^ 0x9e3779b1);
+  const masterRng = new CodinGameRandom(opts.seed ^ 0x9e3779b1);
 
   for (let ep = 0; ep < opts.episodes; ep++) {
     const s = opts.sampler?.(ep, masterRng);

--- a/patches_randomize_training.sh
+++ b/patches_randomize_training.sh
@@ -7,7 +7,7 @@ import { initGame, step } from '@busters/engine';
 import { observationsForTeam } from '@busters/engine';
 import { TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
 import type { Action, AgentContext } from '@busters/shared';
-import { XorShift32 } from '@busters/shared';
+import { CodinGameRandom } from '@busters/shared';
 
 export interface RunOpts {
   seed: number;
@@ -21,7 +21,7 @@ export interface RunOpts {
    * Optional sampler to vary params per episode while keeping determinism.
    * If provided, it overrides bustersPerPlayer/ghostCount/seed for that episode.
    */
-  sampler?: (epIndex: number, rng: XorShift32) => {
+  sampler?: (epIndex: number, rng: CodinGameRandom) => {
     bustersPerPlayer: number;
     ghostCount: number;
     seedOffset?: number; // added to base seed to create the episode seed
@@ -30,7 +30,7 @@ export interface RunOpts {
 
 export async function runEpisodes(opts: RunOpts) {
   let totalScoreA = 0, totalScoreB = 0;
-  const masterRng = new XorShift32(opts.seed ^ 0x9e3779b1);
+  const masterRng = new CodinGameRandom(opts.seed ^ 0x9e3779b1);
 
   for (let ep = 0; ep < opts.episodes; ep++) {
     const s = opts.sampler?.(ep, masterRng);


### PR DESCRIPTION
## Summary
- implement CodinGameRandom to match CodinGame's pseudo-random sequence
- use CodinGameRandom for engine ghost placement and sim-runner episode seeds
- update RNG tests for deterministic sequence and bounds checking

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a608815368832b9b94816badbf9f35