### PR TITLE
Hide opponent stun cooldown in entity list

### DIFF
--- a/packages/engine/src/perception.test.ts
+++ b/packages/engine/src/perception.test.ts
@@ -66,3 +66,27 @@ test('entities are returned sorted by id', () => {
   const sorted = [...ids].sort((a, b) => a - b);
   assert.deepEqual(ids, sorted);
 });
+
+test('enemy stun cooldown is hidden', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
+  const me = state.busters.find(b => b.teamId === 0)!;
+  const enemy = state.busters.find(b => b.teamId === 1)!;
+
+  // Ensure both busters see each other
+  me.x = 0; me.y = 0;
+  enemy.x = 0; enemy.y = 0;
+
+  me.stunCd = 5;
+  enemy.stunCd = 7;
+
+  // Neither buster is carrying, stunned or busting
+  me.state = 0;
+  enemy.state = 0;
+
+  const list = entitiesForTeam(state, 0);
+  const myEntity = list.find(e => e.id === me.id)!;
+  const enemyEntity = list.find(e => e.id === enemy.id)!;
+
+  assert.equal(myEntity.value, 5);
+  assert.equal(enemyEntity.value, 0);
+});

--- a/packages/engine/src/perception.ts
+++ b/packages/engine/src/perception.ts
@@ -108,7 +108,7 @@ export function entitiesForTeam(state: GameState, teamId: TeamId): EntityView[] 
       y: b.y,
       entityType: b.teamId,
       state: b.state,
-      value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : b.stunCd
+      value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : 0
     }));
 
   const ghosts = Array.from(visibleGhosts.values()).map(g => ({


### PR DESCRIPTION
## Summary
- Hide enemy buster stun cooldown unless they are carrying, stunned or busting
- Add test ensuring enemy cooldown is hidden while friendly cooldown remains visible

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a611646a80832bbc4bf9700f222557