### PR TITLE
Handle explicit WAIT actions

### DIFF
--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -1,7 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { initGame, step, ActionsByTeam } from './engine';
+import { parseAction } from './cg-driver';
 import { TEAM0_BASE, RULES, MAX_TICKS } from '@busters/shared';
+
+test('parseAction parses WAIT as explicit action', () => {
+  assert.deepEqual(parseAction('WAIT'), { type: 'WAIT' });
+});
 
 test('loop ends when all ghosts are scored', () => {
   let state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });

--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -1,11 +1,12 @@
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
 import { initGame, step, ActionsByTeam } from './engine';
 import { entitiesForTeam } from './perception';
 import { Action, TeamId, MAX_TICKS } from '@busters/shared';
 
-function parseAction(line: string): Action | undefined {
+export function parseAction(line: string): Action | undefined {
   const parts = line.trim().split(/\s+/);
   const cmd = parts[0]?.toUpperCase();
   switch (cmd) {
@@ -22,7 +23,7 @@ function parseAction(line: string): Action | undefined {
     case 'EJECT':
       return { type: 'EJECT', x: Number(parts[1]), y: Number(parts[2]) };
     case 'WAIT':
-      return undefined;
+      return { type: 'WAIT' };
     default:
       return undefined;
   }
@@ -123,7 +124,9 @@ async function main() {
   bots.forEach(b => b.kill());
 }
 
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -279,6 +279,13 @@ test('attempting BUST while carrying causes ghost escape without scoring', () =>
   assert.equal(escaped.y, b.y);
 });
 
+test('explicit WAIT action behaves as no-op', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
+  const waitNext = step(state, { 0: [{ type: 'WAIT' }], 1: [] } as any);
+  const undefNext = step(state, { 0: [undefined], 1: [] } as any);
+  assert.deepEqual(waitNext, undefNext);
+});
+
 test('eject moves ghost only up to max distance', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const b = state.busters[0];

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -108,7 +108,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
     for (let i = 0; i < teamB.length; i++) {
       const b = teamB[i];
       const a = teamActs[i];
-      if (!a) continue;
+      if (!a || a.type === 'WAIT') continue;
       if (b.state === 2) continue; // stunned cannot act
       switch (a.type) {
         case 'MOVE': intents.set(b.id, { type: 'MOVE', x: clamp(a.x, 0, next.width - 1), y: clamp(a.y, 0, next.height - 1) }); break;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -6,7 +6,8 @@ export type Action =
   | { type: 'RELEASE' }
   | { type: 'STUN'; busterId: number }
   | { type: 'RADAR' }
-  | { type: 'EJECT'; x: number; y: number };
+  | { type: 'EJECT'; x: number; y: number }
+  | { type: 'WAIT' };
 
 export type BusterPublicState = {
   id: number;


### PR DESCRIPTION
## Summary
- Add `WAIT` to `Action` type
- Parse `WAIT` lines into `{ type: 'WAIT' }`
- Ignore `WAIT` in engine `step` and guard cg-driver main execution
- Test explicit `WAIT` parsing and behavior

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6113ef39c832b929dedbf00785fb9