### PR TITLE
Refine cg-driver loop termination

### DIFF
--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { initGame, step, ActionsByTeam } from './engine';
 import { TEAM0_BASE, RULES, MAX_TICKS } from '@busters/shared';
 
-test('loop ends when all ghosts are scored', () => {
+test('loop ends when no ghosts remain and none are carried', () => {
   let state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const b = state.busters[0];
   const ghost = state.ghosts[0];
@@ -15,7 +15,7 @@ test('loop ends when all ghosts are scored', () => {
       ? { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any
       : { 0: [{ type: 'RELEASE' }], 1: [] } as any;
     state = step(state, actions);
-    if (state.scores[0] + state.scores[1] >= state.ghostCount) {
+    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === 1)) {
       break;
     }
   }

--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -114,7 +114,7 @@ async function main() {
     };
 
     state = step(state, actions);
-    if (state.scores[0] + state.scores[1] >= state.ghostCount) {
+    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === 1)) {
       break;
     }
   }


### PR DESCRIPTION
## Summary
- ensure cg-driver ends when all ghosts are off the map and none are carried
- update cg-driver test to match new termination rule

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6116c8474832b81c656b0549d6baa