### PR TITLE
feat(engine): apply official ghost stamina distribution

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -37,6 +37,19 @@ test('lone ghost spawns outside base radius', () => {
   assert.ok(d1 > RULES.BASE_RADIUS);
 });
 
+test('ghost stamina follows official distribution', () => {
+  const total = 1000;
+  const state = initGame({ seed: 123, bustersPerPlayer: 0, ghostCount: total });
+  const counts: Record<number, number> = { 3: 0, 15: 0, 40: 0 };
+  for (const g of state.ghosts) counts[g.endurance]++;
+  const pct3 = counts[3] / total;
+  const pct15 = counts[15] / total;
+  const pct40 = counts[40] / total;
+  assert.ok(Math.abs(pct3 - 0.2) < 0.05);
+  assert.ok(Math.abs(pct15 - 0.6) < 0.05);
+  assert.ok(Math.abs(pct40 - 0.2) < 0.05);
+});
+
 test('initGame places busters and ghosts symmetrically', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 3, ghostCount: 4 });
   const team0 = state.busters.filter(b => b.teamId === 0);


### PR DESCRIPTION
## Summary
- use weighted ghost stamina distribution (3:15:40 -> 20/60/20)
- document distribution and support custom weights
- test distribution proportions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61185f818832bbee0ffe1ae62774a