### PR TITLE
Track last seen buster positions for ghost flee

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -384,9 +384,48 @@ test('ghost flees 400 units after detection', () => {
 
   const mid = step(state, { 0: [], 1: [] } as any);
   mid.lastSeenTickForGhost[ghost.id] = mid.tick - 1;
+  mid.lastSeenByGhost[ghost.id] = [{ x: b.x, y: b.y }];
   const end = step(mid, { 0: [], 1: [] } as any);
   const gEnd = end.ghosts[0];
   assert.equal(gEnd.x, 1900);
   assert.equal(gEnd.y, 1000);
+});
+
+test('ghost flees from last seen position even if buster moves away', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters.find(bs => bs.teamId === 0)!;
+  const enemy = state.busters.find(bs => bs.teamId === 1)!;
+  enemy.x = 0; enemy.y = 5000; // far so it doesn't detect
+  b.x = 1000; b.y = 1000;
+  const ghost = state.ghosts[0];
+  ghost.x = 1500; ghost.y = 1000;
+
+  const mid = step(state, { 0: [], 1: [] } as any);
+  const end = step(mid, { 0: [{ type: 'MOVE', x: 5000, y: 1000 }], 1: [] } as any);
+  const gEnd = end.ghosts[0];
+  assert.equal(gEnd.x, 1900);
+  assert.equal(gEnd.y, 1000);
+});
+
+test('ghost flees from barycenter of last seen busters even after they move away', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b0 = state.busters.find(bs => bs.teamId === 0)!;
+  const b1 = state.busters.find(bs => bs.teamId === 1)!;
+  b0.x = 2000; b0.y = 3000;
+  b1.x = 3000; b1.y = 2000;
+  const ghost = state.ghosts[0];
+  ghost.x = 3000; ghost.y = 3000;
+
+  const mid = step(state, { 0: [], 1: [] } as any);
+  const end = step(
+    mid,
+    {
+      0: [{ type: 'MOVE', x: 6000, y: 3000 }],
+      1: [{ type: 'MOVE', x: 3000, y: 6000 }],
+    } as any,
+  );
+  const gEnd = end.ghosts[0];
+  assert.equal(gEnd.x, 3283);
+  assert.equal(gEnd.y, 3283);
 });
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -40,6 +40,7 @@ export type GameState = {
   ghosts: GhostState[]; // ghosts still on map (not scored)
   radarNextVision: Record<number, boolean>; // busterId -> true if radar effect active for next turn
   lastSeenTickForGhost: Record<number, number>; // ghostId -> last tick any buster detected (for flee timing)
+  lastSeenByGhost: Record<number, Array<{ x: number; y: number }>>; // ghostId -> positions of busters that last spotted it
 };
 
 export type Observation = {


### PR DESCRIPTION
## Summary
- extend `GameState` to track positions of busters that last spotted each ghost
- record spotting buster positions and base ghost flee direction on stored spots
- test that ghosts flee based on last seen positions even if busters move away

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6113a9fd4832b942e3db36d8022d6