### PR TITLE
Validate action parameters in Codingame driver

### DIFF
--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -11,6 +11,11 @@ test('parseAction parses WAIT as explicit action', () => {
   assert.deepEqual(parseAction('WAIT'), { type: 'WAIT' });
 });
 
+test('parseAction returns undefined for malformed inputs', () => {
+  assert.equal(parseAction('MOVE 1000'), undefined);
+  assert.equal(parseAction('BUST notanid'), undefined);
+});
+
 test('loop ends when no ghosts remain and none are carried', () => {
   let state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const b = state.busters[0];

--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -11,17 +11,27 @@ export function parseAction(line: string): Action | undefined {
   const cmd = parts[0]?.toUpperCase();
   switch (cmd) {
     case 'MOVE':
-      return { type: 'MOVE', x: Number(parts[1]), y: Number(parts[2]) };
+      const x = Number(parts[1]);
+      const y = Number(parts[2]);
+      return Number.isFinite(x) && Number.isFinite(y)
+        ? { type: 'MOVE', x, y }
+        : undefined;
     case 'BUST':
-      return { type: 'BUST', ghostId: Number(parts[1]) };
+      const ghostId = Number(parts[1]);
+      return Number.isFinite(ghostId) ? { type: 'BUST', ghostId } : undefined;
     case 'RELEASE':
       return { type: 'RELEASE' };
     case 'STUN':
-      return { type: 'STUN', busterId: Number(parts[1]) };
+      const busterId = Number(parts[1]);
+      return Number.isFinite(busterId) ? { type: 'STUN', busterId } : undefined;
     case 'RADAR':
       return { type: 'RADAR' };
     case 'EJECT':
-      return { type: 'EJECT', x: Number(parts[1]), y: Number(parts[2]) };
+      const ex = Number(parts[1]);
+      const ey = Number(parts[2]);
+      return Number.isFinite(ex) && Number.isFinite(ey)
+        ? { type: 'EJECT', x: ex, y: ey }
+        : undefined;
     case 'WAIT':
       return { type: 'WAIT' };
     default:


### PR DESCRIPTION
## Summary
- ensure coordinates and entity IDs are finite when parsing Codingame bot actions
- treat malformed MOVE/BUST/STUN/EJECT commands as WAIT
- test malformed MOVE and BUST inputs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d689e6d0832b80e115a40581389d