### PR TITLE
Enforce strict BUST range and add boundary tests

### DIFF
--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -16,7 +16,7 @@ test('loop ends when no ghosts remain and none are carried', () => {
   const b = state.busters[0];
   const ghost = state.ghosts[0];
   b.x = TEAM0_BASE.x; b.y = TEAM0_BASE.y;
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
   // emulate driver loop
   while (state.tick < MAX_TICKS) {
     const actions: ActionsByTeam = state.tick === 0

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -97,7 +97,7 @@ test('step captures ghost when endurance drops to zero', () => {
   const b = state.busters.find(bs => bs.teamId === 0)!;
   b.x = 1000; b.y = 1000;
   const ghost = state.ghosts[0];
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
   const actions: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const next = step(state, actions);
   const carrier = next.busters[0];
@@ -106,12 +106,29 @@ test('step captures ghost when endurance drops to zero', () => {
   assert.equal(carrier.value, ghost.id);
 });
 
+test('busters cannot bust at boundary distances', () => {
+  const attempt = (distance: number) => {
+    const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+    const b = state.busters[0];
+    b.x = 1000; b.y = 1000;
+    const ghost = state.ghosts[0];
+    ghost.x = b.x + distance; ghost.y = b.y; ghost.endurance = 1;
+    const next = step(state, { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any);
+    const bNext = next.busters[0];
+    assert.equal(next.ghosts.length, 1);
+    assert.equal(next.ghosts[0].endurance, 1);
+    assert.equal(bNext.state, 0);
+  };
+  attempt(RULES.BUST_MIN);
+  attempt(RULES.BUST_MAX);
+});
+
 test('step scores when releasing carried ghost in base', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const b = state.busters[0];
   b.x = TEAM0_BASE.x; b.y = TEAM0_BASE.y;
   const ghost = state.ghosts[0];
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
 
   const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const mid = step(state, capture);
@@ -130,7 +147,7 @@ test('release outside base decrements score', () => {
   // start outside base
   b.x = TEAM0_BASE.x + RULES.BASE_RADIUS + RULES.BUST_MIN + 10; b.y = TEAM0_BASE.y;
   const ghost = state.ghosts[0];
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
 
   const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const mid = step(state, capture);
@@ -383,7 +400,7 @@ test('busting state persists into next turn until another action', () => {
   const b = state.busters[0];
   const ghost = state.ghosts[0];
   b.x = 1000; b.y = 1000;
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 2;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 2;
 
   const bust: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const mid = step(state, bust);

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -293,7 +293,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
       const g = ghostById.get(a.ghostId);
       if (!g) continue;
       const d = dist(b.x, b.y, g.x, g.y);
-      if (d >= RULES.BUST_MIN && d <= RULES.BUST_MAX) {
+      if (d > RULES.BUST_MIN && d < RULES.BUST_MAX) {
         const acc = bustingByGhost.get(g.id)!;
         acc.byTeam[b.teamId] += 1;
         const d2curr = dist2(b.x, b.y, g.x, g.y);


### PR DESCRIPTION
## Summary
- Disallow busting exactly at BUST_MIN and BUST_MAX distances
- Add regression tests for bust boundary cases and update existing captures
- Update driver test to respect new bust range

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d69991f8832b90e32b9f9e5b1c8c