### PR TITLE
Penalize opponent-base releases

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -148,6 +148,28 @@ test('release outside base decrements score', () => {
   assert.equal(dropped.y, b.y);
 });
 
+test('release inside opponent base awards opponent and penalizes releaser', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters[0];
+  b.x = 1000; b.y = 1000;
+  const ghost = state.ghosts[0];
+  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+
+  const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
+  const mid = step(state, capture);
+
+  const carrier = mid.busters[0];
+  carrier.x = TEAM1_BASE.x; carrier.y = TEAM1_BASE.y;
+
+  const release: ActionsByTeam = { 0: [{ type: 'RELEASE' }], 1: [] } as any;
+  const end = step(mid, release);
+  const bEnd = end.busters[0];
+  assert.equal(end.scores[1], 1);
+  assert.equal(end.scores[0], -1);
+  assert.equal(bEnd.state, 0);
+  assert.equal(bEnd.value, 0);
+});
+
 test('stun drops carried ghost and sets cooldown', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
   const attacker = state.busters.find(b => b.teamId === 0)!;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -241,6 +241,9 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
         if (baseTeam !== null) {
           // score + ghost removed from game
           next.scores[baseTeam] += 1;
+          if (baseTeam !== b.teamId) {
+            next.scores[b.teamId] -= 1;
+          }
           // (ghost was already removed from map when captured)
           b.state = 0; b.value = 0;
         } else {


### PR DESCRIPTION
## Summary
- Deduct a point from a team that releases a ghost in the opponent's base
- Add regression test to ensure opponent-base releases award the base and penalize the releaser

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d6ade580832bbd50d475c0635efb