### PR TITLE
Penalize releases in enemy base

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -133,10 +133,31 @@ test('step scores when releasing carried ghost in base', () => {
   const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const mid = step(state, capture);
 
+const release: ActionsByTeam = { 0: [{ type: 'RELEASE' }], 1: [] } as any;
+const end = step(mid, release);
+const bEnd = end.busters[0];
+assert.equal(end.scores[0], 1);
+assert.equal(bEnd.state, 0);
+assert.equal(bEnd.value, 0);
+});
+
+test('release inside opponent base scores for opponent and decrements releaser', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
+  const b = state.busters.find(bs => bs.teamId === 0)!;
+  const ghost = state.ghosts[0];
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
+
+  const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
+  const mid = step(state, capture);
+
+  const carrier = mid.busters[0];
+  carrier.x = TEAM1_BASE.x; carrier.y = TEAM1_BASE.y;
+
   const release: ActionsByTeam = { 0: [{ type: 'RELEASE' }], 1: [] } as any;
   const end = step(mid, release);
   const bEnd = end.busters[0];
-  assert.equal(end.scores[0], 1);
+  assert.equal(end.scores[1], 1);
+  assert.equal(end.scores[0], -1);
   assert.equal(bEnd.state, 0);
   assert.equal(bEnd.value, 0);
 });
@@ -172,7 +193,7 @@ test('release at base radius does not score', () => {
   // place exactly on base boundary
   b.x = boundaryX; b.y = TEAM0_BASE.y;
   const ghost = state.ghosts[0];
-  ghost.x = b.x + RULES.BUST_MIN; ghost.y = b.y; ghost.endurance = 1;
+  ghost.x = b.x + RULES.BUST_MIN + 1; ghost.y = b.y; ghost.endurance = 1;
 
   const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;
   const mid = step(state, capture);
@@ -227,7 +248,7 @@ test('stun drop at base radius does not score', () => {
   attacker.x = boundaryX + RULES.STUN_RANGE - 1; attacker.y = victim.y;
 
   const ghost = state.ghosts[0];
-  ghost.x = victim.x + RULES.BUST_MIN; ghost.y = victim.y; ghost.endurance = 1;
+  ghost.x = victim.x + RULES.BUST_MIN + 1; ghost.y = victim.y; ghost.endurance = 1;
 
   // victim captures ghost
   const capture: ActionsByTeam = { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -241,6 +241,10 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
         if (baseTeam !== null) {
           // score + ghost removed from game
           next.scores[baseTeam] += 1;
+          // releasing in opponent base penalizes the releaser
+          if (baseTeam !== b.teamId) {
+            next.scores[b.teamId] -= 1;
+          }
           // (ghost was already removed from map when captured)
           b.state = 0; b.value = 0;
         } else {


### PR DESCRIPTION
## Summary
- Deduct a point from a team that releases a ghost inside the opposing base
- Add regression test for releasing inside opponent base
- Place ghosts just within bust range in base radius tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d89085c0832b811fb69eec5ee3a6