### PR TITLE
Use exporter script for CodinGame bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pnpm cg:export:champ    # champion from tournament standings
 
 `cg:export:genome` reads `packages/sim-runner/artifacts/simrunner_best_genome.json` (or `artifacts/simrunner_best_genome.json` if present). `cg:export:champ` picks the top entry in `packages/sim-runner/artifacts/tournament_standings.json`. Paste the resulting `agents/codingame-bot.js` into the CodinGame IDE.
 
+The long training helper (`scripts/train_long.sh`) runs this exporter automatically, writing `agents/evolved-bot.cg.js` with a full `readline()`/`console.log()` loop and without optional chaining so it executes in the CodinGame IDE.
+
 ## Run Local Tournaments
 Short names `greedy`, `random`, `evolved` are resolved by the loader to absolute file paths.
 

--- a/scripts/train_long.sh
+++ b/scripts/train_long.sh
@@ -110,12 +110,15 @@ TOP_BOT="agents/evolved-bot.js"
 CG_BOT="agents/evolved-bot.cg.js"
 
 if [[ -f "$TOP_BOT" ]]; then
-  echo ">> Exporting CodinGame-compatible bot -> $CG_BOT"
-  # Strip ESM exports so you can paste it directly in CodinGame
-  sed -E 's/^export (const|function) /\1 /' "$TOP_BOT" > "$CG_BOT"
-  # Timestamped backups
+  echo ">> Exporting CodinGame-compatible bot via scripts/export-codingame.ts -> $CG_BOT"
+  if [[ "$SUBJECT" == "hybrid" ]]; then
+    pnpm tsx scripts/export-codingame.ts --from hybrid --weights "$BEST_ART" --out "$CG_BOT"
+  else
+    pnpm tsx scripts/export-codingame.ts --from genome --out "$CG_BOT"
+  fi
+  # Timestamped backups of both ESM & CG variants
   cp "$TOP_BOT" "agents/evolved-bot.${TS}.${TAG}.js"
-  cp "$CG_BOT"  "agents/evolved-bot.${TS}.${TAG}.cg.js"
+  cp "$CG_BOT" "agents/evolved-bot.${TS}.${TAG}.cg.js"
 else
   echo "WARN: $TOP_BOT not found — did training generate it?"
 fi


### PR DESCRIPTION
## Summary
- replace `sed` hack in `train_long.sh` with `scripts/export-codingame.ts` to build CodinGame bot
- document automatic export with full `readline` loop and no optional chaining

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4dfaf20832bb7566406dbf11e0d