### PR TITLE
Reset patrol indices on match restart

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { act, __mem } from './hybrid-bot';
+import { act, __mem, __pMem } from './hybrid-bot';
 
 test('mem resets on new match and repopulates', () => {
   // pre-populate with stale entry
@@ -15,4 +15,18 @@ test('mem resets on new match and repopulates', () => {
   const nextObs: any = { tick: 2, self: { id: 2, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
   act(ctx, nextObs);
   assert.ok(__mem.has(1) && __mem.has(2));
+});
+
+test('patrol indices reset on new match', () => {
+  // seed patrol memory with stale waypoint
+  __pMem.set(1, { wp: 3 });
+  __pMem.set(99, { wp: 2 });
+
+  const ctx: any = {};
+  const obs: any = { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
+  act(ctx, obs);
+
+  // old entries cleared and waypoint reset to zero
+  assert.equal(__pMem.get(1)?.wp, 0);
+  assert.ok(!__pMem.has(99));
 });

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -188,6 +188,7 @@ function buildTasks(ctx: Ctx, meObs: Obs, state: HybridState, MY: Pt, EN: Pt): T
 
 /** tiny patrol memory for exploration */
 const pMem = new Map<number, { wp: number }>();
+export const __pMem = pMem; // exposed for tests
 function MPatrol(id: number) { if (!pMem.has(id)) pMem.set(id, { wp: 0 }); return pMem.get(id)!; }
 
 /** Score of assigning buster -> task (bigger is better) */
@@ -266,7 +267,13 @@ function runAuction(team: Ent[], tasks: Task[], enemies: Ent[], MY: Pt, tick: nu
 /** --- Main per-buster policy --- */
 export function act(ctx: Ctx, obs: Obs) {
   const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
-  if (tick <= 1 && tick < lastTick) { mem.clear(); fog.reset(); }
+  if (tick <= 1 && tick < lastTick) {
+    mem.clear();
+    pMem.clear();
+    planTick = -1;
+    planAssign.clear();
+    fog.reset();
+  }
   lastTick = tick;
   const me = obs.self;
   const m = M(me.id);


### PR DESCRIPTION
## Summary
- Clear patrol memory and shared plan caches when a new match begins
- Expose patrol memory for tests and verify indices reset to zero

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70836c724832b9931a298ade80101