### PR TITLE
feat: add support stun tasks

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -62,3 +62,19 @@ test('fog heat diffuses, normalizes, and reduces when visited', () => {
   const after = (f as any).heat[idx];
   assert.ok(after < before);
 });
+
+test('assigns support task when ally engages enemy near ghost', () => {
+  // reset state for a new match
+  act({}, { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] });
+
+  const ctx: any = { tick: 10, myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 }, bustersPerPlayer: 2 };
+  const obs: any = {
+    tick: 10,
+    self: { id: 2, x: 4050, y: 4050, state: 0, stunCd: 5 },
+    friends: [{ id: 3, x: 2000, y: 2000, state: 0 }],
+    enemies: [{ id: 5, x: 4100, y: 4100, state: 0 }],
+    ghostsVisible: [{ id: 7, x: 4000, y: 4000 }],
+  };
+  const res: any = act(ctx, obs);
+  assert.equal(res.__dbg.tag, 'SUPPORT');
+});

--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -28,6 +28,8 @@ export type Weights = {
   BLOCK_BASE: number;           // base utility for blocker tasks
   EXPLORE_BASE: number;         // base utility for explore tasks
   DIST_PEN: number;             // generic distance penalty
+  SUPPORT_BASE: number;         // base utility for support-stun tasks
+  SUPPORT_CONTEST_BONUS: number;// bonus if supporting a contested ghost
 };
 
 // -----------------------------------------------------------------------------
@@ -56,6 +58,8 @@ export const WEIGHTS: Weights = {
   BLOCK_BASE: 6,
   EXPLORE_BASE: 4,
   DIST_PEN: 0.003,
+  SUPPORT_BASE: 11,
+  SUPPORT_CONTEST_BONUS: 3,
 };
 
 // Default export (some loaders import default)


### PR DESCRIPTION
## Summary
- extend task planning with SUPPORT role for ally or ghost engagements
- weight and scoring logic for support stuns
- add regression test for support task assignment

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a746049088832b8feac163c9210ff4