### PR TITLE
feat: add micro simulator for tactical evaluation

### DIFF
--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -338,7 +338,7 @@ export function act(ctx: Ctx, obs: Obs) {
       canStunMe: true,
       canStunEnemy: targetEnemy.state !== 2,
       stunRange: TUNE.STUN_RANGE,
-    });
+    }) + (targetEnemy.state === 1 ? releaseBlockDelta({ blocker: me, carrier: targetEnemy, myBase: MY, stunRange: TUNE.STUN_RANGE }) : 0);
     if (duel >= 0) {
       mem.get(me.id)!.stunReadyAt = tick + STUN_CD;
       return dbg({ type: "STUN", busterId: targetEnemy.id }, "STUN", targetEnemy.state === 1 ? "enemy_carrier" : "threat");

--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { contestedBustDelta, duelStunDelta, releaseBlockDelta } from './micro';
+
+// Verify contested bust uses projected positions
+const STUN = 1760;
+const BUST_MIN = 900;
+const BUST_MAX = 1760;
+
+test('contested bust projects one turn ahead', () => {
+  const me = { id: 1, x: 2000, y: 0 };
+  const ghost = { x: 0, y: 0 };
+  // entering ring next turn grants positive delta
+  const alone = contestedBustDelta({
+    me,
+    ghost,
+    enemies: [],
+    bustMin: BUST_MIN,
+    bustMax: BUST_MAX,
+    stunRange: STUN,
+    canStunMe: true,
+  });
+  assert.ok(alone > 0);
+  // enemy becomes nearby after one move -> negative delta
+  const enemy = { id: 2, x: 2600, y: 0 };
+  const contested = contestedBustDelta({
+    me,
+    ghost,
+    enemies: [enemy],
+    bustMin: BUST_MIN,
+    bustMax: BUST_MAX,
+    stunRange: STUN,
+    canStunMe: true,
+  });
+  assert.ok(contested < 0);
+});
+
+test('duel stun projects closing distance', () => {
+  const me = { id: 1, x: 0, y: 0 };
+  const enemy = { id: 2, x: 2500, y: 0 };
+  const delta = duelStunDelta({
+    me,
+    enemy,
+    canStunMe: true,
+    canStunEnemy: false,
+    stunRange: STUN,
+  });
+  assert.ok(delta > 0);
+});
+
+test('release block projects carrier path', () => {
+  const blocker = { id: 1, x: 3200, y: 0 };
+  const carrier = { id: 2, x: 2600, y: 0 };
+  const myBase = { x: 0, y: 0 };
+  const delta = releaseBlockDelta({ blocker, carrier, myBase, stunRange: STUN });
+  assert.ok(delta > 0);
+});

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -10,6 +10,14 @@ function dist(ax: number, ay: number, bx: number, by: number) {
   return Math.hypot(ax - bx, ay - by);
 }
 
+/** Advance point p one turn toward q at normal speed. */
+function step(p: Pt, q: Pt): Pt {
+  const dx = q.x - p.x, dy = q.y - p.y;
+  const d = Math.hypot(dx, dy);
+  if (d <= SPEED) return { x: q.x, y: q.y };
+  return { x: p.x + (dx / d) * SPEED, y: p.y + (dy / d) * SPEED };
+}
+
 /** Return a point on the enemy->myBase line where I can plausibly meet/beat the enemy. */
 export function estimateInterceptPoint(me: Pt, enemy: Pt, myBase: Pt): Pt {
   const ex = enemy.x, ey = enemy.y;
@@ -36,7 +44,9 @@ export function duelStunDelta(opts: {
   me: Ent; enemy: Ent; canStunMe: boolean; canStunEnemy: boolean; stunRange: number;
 }) {
   const { me, enemy, canStunMe, canStunEnemy, stunRange } = opts;
-  const r = enemy.range ?? dist(me.x, me.y, enemy.x, enemy.y);
+  const me1 = step(me, enemy);
+  const enemy1 = step(enemy, me);
+  const r = dist(me1.x, me1.y, enemy1.x, enemy1.y);
   if (r > stunRange) return 0;
   if (canStunMe && !canStunEnemy) return +1.0;     // I win the duel now
   if (!canStunMe && canStunEnemy) return -1.0;     // I lose the duel now
@@ -49,9 +59,11 @@ export function contestedBustDelta(opts: {
   me: Ent; ghost: Pt & { id?: number }; enemies: Ent[]; bustMin: number; bustMax: number; stunRange: number; canStunMe: boolean;
 }) {
   const { me, ghost, enemies, bustMin, bustMax, stunRange, canStunMe } = opts;
-  const r = dist(me.x, me.y, ghost.x, ghost.y);
-  const near = enemies.filter(e => dist(e.x, e.y, ghost.x, ghost.y) <= 2200);
-  if (near.length === 0) return 0;
+  const me1 = step(me, ghost);
+  const enemies1 = enemies.map(e => step(e, ghost));
+  const r = dist(me1.x, me1.y, ghost.x, ghost.y);
+  const near = enemies1.filter(e => dist(e.x, e.y, ghost.x, ghost.y) <= 2200);
+  if (near.length === 0) return (r >= bustMin && r <= bustMax) ? +0.25 : 0;
 
   let delta = 0;
   // Being on the ring is good, but danger increases with nearby enemies.
@@ -59,7 +71,7 @@ export function contestedBustDelta(opts: {
   delta += -0.35 * near.length; // risk penalty per nearby enemy
 
   // If at least one enemy is in stun range and I *can’t* stun now, penalize a bit more
-  const enemyInStun = near.some(e => (e.range ?? dist(me.x, me.y, e.x, e.y)) <= stunRange);
+  const enemyInStun = near.some(e => dist(me1.x, me1.y, e.x, e.y) <= stunRange);
   if (enemyInStun && !canStunMe) delta -= 0.3;
 
   return delta;
@@ -70,15 +82,18 @@ export function releaseBlockDelta(opts: {
   blocker: Ent; carrier: Ent; myBase: Pt; stunRange: number;
 }) {
   const { blocker, carrier, myBase, stunRange } = opts;
-  const dCarrierToBase = dist(carrier.x, carrier.y, myBase.x, myBase.y);
+  // project both one step forward
+  const carrier1 = step(carrier, myBase);
+  const dCarrierToBase = dist(carrier1.x, carrier1.y, myBase.x, myBase.y);
   // pick a meet point ~ one ring outside release distance
   const RELEASE_DIST = 1600;
-  const need = Math.max(0, dCarrierToBase - (RELEASE_DIST + 150)); // intercept before safe zone
-  const ux = (myBase.x - carrier.x), uy = (myBase.y - carrier.y);
+  const need = Math.max(0, dCarrierToBase - (RELEASE_DIST + 150));
+  const ux = (myBase.x - carrier1.x), uy = (myBase.y - carrier1.y);
   const L = Math.hypot(ux, uy) || 1;
-  const px = carrier.x + (ux / L) * need, py = carrier.y + (uy / L) * need;
+  const px = carrier1.x + (ux / L) * need, py = carrier1.y + (uy / L) * need;
 
-  const tMe = dist(blocker.x, blocker.y, px, py) / SPEED;
+  const blocker1 = step(blocker, { x: px, y: py });
+  const tMe = dist(blocker1.x, blocker1.y, px, py) / SPEED;
   const tEn = need / SPEED;
 
   // If I arrive significantly earlier, good block; if later by a lot, bad
@@ -88,7 +103,7 @@ export function releaseBlockDelta(opts: {
   else if (lead > +0.5) delta += 0.6;
 
   // extra bonus if that intercept point is within stun range of carrier path
-  const dr = dist(blocker.x, blocker.y, px, py);
+  const dr = dist(blocker1.x, blocker1.y, px, py);
   if (dr <= stunRange + 200) delta += 0.25;
 
   return delta;


### PR DESCRIPTION
## Summary
- project unit positions one turn ahead for duels, contested busts, and release blocks
- use projected release-block value when evaluating stun targets
- cover micro heuristics with unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a74610b3b4832b9d988f4c891ba29e