### PR TITLE
Ignore stunned enemies for stun targeting

### DIFF
--- a/agents/codingame-bot.js
+++ b/agents/codingame-bot.js
@@ -70,8 +70,14 @@ while (true) {
     // 2) STUN priority: enemy carrying within STUN_RANGE, else nearest enemy within BUST_MAX
     const canStun = (tick >= m.stunReadyAt) && !stunned;
     let toStun = null;
-    for (const er of enemiesR){ if (er.e.state===1 && er.r <= STUN_RANGE) { toStun = er.e; break; } }
-    if (!toStun && enemiesR.length && enemiesR[0].r <= BUST_MAX) toStun = enemiesR[0].e;
+    for (const er of enemiesR){
+      if (er.e.state === 2) continue;
+      if (er.e.state===1 && er.r <= STUN_RANGE) { toStun = er.e; break; }
+    }
+    if (!toStun){
+      const cand = enemiesR.find(er => er.e.state !== 2 && er.r <= BUST_MAX);
+      if (cand) toStun = cand.e;
+    }
     if (canStun && toStun){ actions[ai] = 'STUN '+toStun.id; m.stunReadyAt = tick + STUN_CD; continue; }
 
     // 3) RADAR once at RADAR_TURN by scout

--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -90,3 +90,20 @@ test('runAuction aligns with Hungarian optimal assignment', () => {
     }
   }
 });
+
+test('bot does not stun an already stunned enemy', () => {
+  __mem.clear();
+  const ctx: any = {};
+  const self = { id: 1, x: 0, y: 0, state: 0 };
+  let obs: any = { tick: 0, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
+  let action = act(ctx, obs);
+  assert.equal(action.type, 'STUN');
+
+  obs = { tick: 21, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 2, range: 0, stunnedFor: 5 }], ghostsVisible: [] };
+  action = act(ctx, obs);
+  assert.notEqual(action.type, 'STUN');
+
+  obs = { tick: 22, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
+  action = act(ctx, obs);
+  assert.equal(action.type, 'STUN');
+});

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -45,7 +45,7 @@ type Ctx = {
   bustersPerPlayer?: number;
 };
 
-type Ent = { id: number; x: number; y: number; range?: number; state?: number; value?: number };
+type Ent = { id: number; x: number; y: number; range?: number; state?: number; value?: number; stunnedFor?: number };
 
 type Obs = {
   tick: number;
@@ -347,9 +347,12 @@ export function act(ctx: Ctx, obs: Obs) {
   }
 
   // Stun priority: enemy carrier in range, else nearest in bust range
-  let targetEnemy: Ent | undefined = enemies.find(e => e.state === 1 && (e.range ?? dist(me.x,me.y,e.x,e.y)) <= TUNE.STUN_RANGE);
-  if (!targetEnemy && enemies.length && (enemies[0].range ?? dist(me.x,me.y,enemies[0].x,enemies[0].y)) <= BUST_MAX) {
-    targetEnemy = enemies[0];
+  let targetEnemy: Ent | undefined = enemies.find(e =>
+    e.state === 1 && (e.stunnedFor ?? 0) <= 0 && (e.range ?? dist(me.x,me.y,e.x,e.y)) <= TUNE.STUN_RANGE);
+  if (!targetEnemy) {
+    const cand = enemies.find(e =>
+      e.state !== 2 && (e.stunnedFor ?? 0) <= 0 && (e.range ?? dist(me.x,me.y,e.x,e.y)) <= BUST_MAX);
+    if (cand) targetEnemy = cand;
   }
   if (canStun && targetEnemy) {
     const duel = duelStunDelta({


### PR DESCRIPTION
## Summary
- Skip currently stunned enemies during stun targeting in Codingame and hybrid bots
- Extend hybrid bot enemy type and logic to avoid restunning stunned foes
- Test that hybrid bot waits for stun to wear off before restunning

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7790793e8832b9eb2099e49909fca