### PR TITLE
feat: add support task support to hybrid bot

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -107,3 +107,15 @@ test('bot does not stun an already stunned enemy', () => {
   action = act(ctx, obs);
   assert.equal(action.type, 'STUN');
 });
+
+test('scoreAssign rewards ready stuns for SUPPORT tasks', () => {
+  __mem.clear();
+  const b: any = { id: 1, x: 0, y: 0 };
+  const task: any = { type: 'SUPPORT', target: { x: 0, y: 0 }, payload: { allyIds: [2] }, baseScore: 0 };
+  const enemies: any[] = [{ id: 3, x: 0, y: 0 }];
+  const MY = { x: 0, y: 0 };
+  let s1 = __scoreAssign(b, task, enemies, MY, 0);
+  __mem.get(1)!.stunReadyAt = 5;
+  let s2 = __scoreAssign(b, task, enemies, MY, 0);
+  assert.ok(s1 > s2);
+});

--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -27,6 +27,7 @@ export type Weights = {
   DEFEND_NEAR_BONUS: number;    // extra bonus if threat near base
   BLOCK_BASE: number;           // base utility for blocker tasks
   EXPLORE_BASE: number;         // base utility for explore tasks
+  SUPPORT_BASE: number;         // base utility for support tasks
   DIST_PEN: number;             // generic distance penalty
 };
 
@@ -55,6 +56,7 @@ export const WEIGHTS: Weights = {
   DEFEND_NEAR_BONUS: 4,
   BLOCK_BASE: 5,
   EXPLORE_BASE: 3,
+  SUPPORT_BASE: 8,
   DIST_PEN: 0.0024519620026867764,
 };
 


### PR DESCRIPTION
## Summary
- add SUPPORT task type for hybrid bot with heuristics for contested ghosts and stun chains
- score and act on support tasks including stun/bust options
- cover support task scoring with new tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78aba1260832b996a4b9f44f8d99e