### PR TITLE
feat: simulate two-turn contests for micro heuristics

### DIFF
--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -77,6 +77,41 @@ export function contestedBustDelta(opts: {
   return delta;
 }
 
+/** Extra lookahead: simulate two alternating moves and re-evaluate bust/duel deltas. */
+export function twoTurnContestDelta(opts: {
+  me: Ent;
+  enemy: Ent;
+  ghost?: Pt & { id?: number };
+  bustMin: number;
+  bustMax: number;
+  stunRange: number;
+  canStunMe: boolean;
+  canStunEnemy: boolean;
+}) {
+  const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
+  const me1 = step(me, ghost ?? enemy);
+  const enemy1 = step(enemy, ghost ?? me);
+  let delta = duelStunDelta({
+    me: me1,
+    enemy: enemy1,
+    canStunMe,
+    canStunEnemy,
+    stunRange,
+  });
+  if (ghost) {
+    delta += contestedBustDelta({
+      me: me1,
+      ghost,
+      enemies: [enemy1],
+      bustMin,
+      bustMax,
+      stunRange,
+      canStunMe,
+    });
+  }
+  return delta;
+}
+
 /** Value for blocking an enemy carrier before they can RELEASE near my base. */
 export function releaseBlockDelta(opts: {
   blocker: Ent; carrier: Ent; myBase: Pt; stunRange: number;


### PR DESCRIPTION
## Summary
- add `twoTurnContestDelta` to project two alternating moves for duels and contested busts
- use two-turn simulation in hybrid bot scoring and candidate evaluation when enemies are near or releases threatened
- test additional lookahead logic for duel and bust scenarios

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78ac13e78832b97cc53a10d38211f