### PR TITLE
feat: add carry task handling and scoring

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -107,3 +107,27 @@ test('bot does not stun an already stunned enemy', () => {
   action = act(ctx, obs);
   assert.equal(action.type, 'STUN');
 });
+
+test('carrying buster receives CARRY task', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const obs: any = { tick: 0, self: { id: 1, x: 8000, y: 4500, state: 1 }, friends: [], enemies: [], ghostsVisible: [] };
+  const action: any = act(ctx, obs);
+  assert.equal(action.type, 'MOVE');
+  assert.equal(action.__dbg?.tag, 'MOVE_CARRY');
+});
+
+test('carrier can switch to intercept task', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const obs: any = {
+    tick: 1,
+    self: { id: 1, x: 2000, y: 1500, state: 1 },
+    friends: [],
+    enemies: [{ id: 2, x: 2100, y: 1600, state: 1 }],
+    ghostsVisible: [],
+  };
+  const action: any = act(ctx, obs);
+  assert.equal(action.type, 'STUN');
+  assert.equal(action.__dbg?.tag, 'STUN');
+});

--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -27,6 +27,7 @@ export type Weights = {
   DEFEND_NEAR_BONUS: number;    // extra bonus if threat near base
   BLOCK_BASE: number;           // base utility for blocker tasks
   EXPLORE_BASE: number;         // base utility for explore tasks
+  CARRY_BASE: number;           // base utility for carry tasks
   DIST_PEN: number;             // generic distance penalty
 };
 
@@ -55,6 +56,7 @@ export const WEIGHTS: Weights = {
   DEFEND_NEAR_BONUS: 4,
   BLOCK_BASE: 5,
   EXPLORE_BASE: 3,
+  CARRY_BASE: 14,
   DIST_PEN: 0.0024519620026867764,
 };
 


### PR DESCRIPTION
## Summary
- add CARRY task generation for busters holding ghosts with risk-aware scoring
- support CARRY tasks in assignment scoring and candidate action generation
- test carriers return home and can switch roles when threats appear

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78ad22b80832b8e79ced6e89db39e