### PR TITLE
feat: eject defensive logic

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -116,8 +116,40 @@ test('scoreAssign rewards ready stuns for SUPPORT tasks', () => {
   const task: any = { type: 'SUPPORT', target: { x: 0, y: 0 }, payload: { allyIds: [2] }, baseScore: 0 };
   const enemies: any[] = [{ id: 3, x: 0, y: 0 }];
   const MY = { x: 0, y: 0 };
-  let s1 = __scoreAssign(b, task, enemies, MY, 0);
+  const st = new HybridState();
+  st.updateRoles([b]);
+  let s1 = __scoreAssign(b, task, enemies, MY, 0, st);
   __mem.get(1)!.stunReadyAt = 5;
-  let s2 = __scoreAssign(b, task, enemies, MY, 0);
+  let s2 = __scoreAssign(b, task, enemies, MY, 0, st);
   assert.ok(s1 > s2);
+});
+
+test('ejects when threatened and stun on cooldown', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const self = { id: 1, x: 4000, y: 4000, state: 1, stunCd: 5 };
+  const enemy = { id: 2, x: 4200, y: 4000, state: 0, range: 200, stunnedFor: 0 };
+  const obs: any = { tick: 10, self, friends: [], enemies: [enemy], ghostsVisible: [] };
+  const actRes = act(ctx, obs);
+  assert.equal(actRes.type, 'EJECT');
+});
+
+test('ejects to closer ally when safe', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const self = { id: 1, x: 6000, y: 6000, state: 1, stunCd: 10 };
+  const ally = { id: 3, x: 5000, y: 5000, state: 0 };
+  const obs: any = { tick: 5, self, friends: [ally], enemies: [], ghostsVisible: [] };
+  const actRes = act(ctx, obs);
+  assert.equal(actRes.type, 'EJECT');
+});
+
+test('does not eject when stun ready', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const self = { id: 1, x: 4000, y: 4000, state: 1, stunCd: 0 };
+  const enemy = { id: 2, x: 4200, y: 4000, state: 0, range: 200, stunnedFor: 0 };
+  const obs: any = { tick: 10, self, friends: [], enemies: [enemy], ghostsVisible: [] };
+  const actRes = act(ctx, obs);
+  assert.notEqual(actRes.type, 'EJECT');
 });

--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta } from './micro';
+import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta } from './micro';
 
 // Verify contested bust uses projected positions
 const STUN = 1760;
@@ -103,5 +103,14 @@ test('release block projects carrier path', () => {
   const carrier = { id: 2, x: 2600, y: 0 };
   const myBase = { x: 0, y: 0 };
   const delta = releaseBlockDelta({ blocker, carrier, myBase, stunRange: STUN });
+  assert.ok(delta > 0);
+});
+
+test('ejectDelta favors progress and ally handoff', () => {
+  const me = { id: 1, x: 4000, y: 4000 };
+  const target = { x: 3500, y: 3500 };
+  const myBase = { x: 0, y: 0 };
+  const ally = { id: 2, x: 3300, y: 3300 };
+  const delta = ejectDelta({ me, target, myBase, ally });
   assert.ok(delta > 0);
 });

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -144,6 +144,25 @@ export function releaseBlockDelta(opts: {
   return delta;
 }
 
+/**
+ * Heuristic value for ejecting a carried ghost toward some point.
+ * Rewards progress toward base and slight bonus if an ally is nearer
+ * to the landing spot than the ejecting buster (handoff).
+ */
+export function ejectDelta(opts: { me: Ent; target: Pt; myBase: Pt; ally?: Ent }) {
+  const { me, target, myBase, ally } = opts;
+  const before = dist(me.x, me.y, myBase.x, myBase.y);
+  const after = dist(target.x, target.y, myBase.x, myBase.y);
+  // progress toward base scaled to small heuristic range
+  let delta = (before - after) * 0.001;
+  if (ally) {
+    const meTo = dist(me.x, me.y, target.x, target.y);
+    const allyTo = dist(ally.x, ally.y, target.x, target.y);
+    if (allyTo < meTo) delta += 0.25;
+  }
+  return delta;
+}
+
 /** Simple additive scoring helper for candidate actions. */
 export type CandidateScore = { base: number; deltas?: number[] };
 export function scoreCandidate(c: CandidateScore): number {


### PR DESCRIPTION
## Summary
- teach hybrid bot to eject when threatened or handing off to a closer ally
- score and consider eject actions during task follow-through
- add micro heuristic and tests for eject behavior

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a824ec9f84832b90d719eb52311256