### PR TITLE
feat: add carry task logic and scoring

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -116,8 +116,33 @@ test('scoreAssign rewards ready stuns for SUPPORT tasks', () => {
   const task: any = { type: 'SUPPORT', target: { x: 0, y: 0 }, payload: { allyIds: [2] }, baseScore: 0 };
   const enemies: any[] = [{ id: 3, x: 0, y: 0 }];
   const MY = { x: 0, y: 0 };
-  let s1 = __scoreAssign(b, task, enemies, MY, 0);
+  const st = new HybridState();
+  st.updateRoles([{ id: 1 } as any]);
+  let s1 = __scoreAssign(b, task, enemies, MY, 0, st);
   __mem.get(1)!.stunReadyAt = 5;
-  let s2 = __scoreAssign(b, task, enemies, MY, 0);
+  let s2 = __scoreAssign(b, task, enemies, MY, 0, st);
   assert.ok(s1 > s2);
+});
+
+test('carrying buster gets CARRY task and moves home', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  const obs: any = { tick: 0, self: { id: 1, x: 3000, y: 3000, state: 1 }, friends: [], enemies: [], ghostsVisible: [] };
+  const action = act(ctx, obs) as any;
+  assert.equal(action.type, 'MOVE');
+  assert.equal(action.__dbg.tag, 'MOVE_CARRY');
+});
+
+test('carrying buster can switch to intercept task', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 }, tick: 1 };
+  const obs: any = {
+    tick: 1,
+    self: { id: 1, x: 6000, y: 4500, state: 1 },
+    friends: [],
+    enemies: [{ id: 2, x: 7000, y: 6500, state: 1 }],
+    ghostsVisible: [],
+  };
+  const action = act(ctx, obs) as any;
+  assert.equal(action.__dbg.tag, 'MOVE_INT');
 });

--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -23,6 +23,8 @@ export type Weights = {
   BUST_ENEMY_NEAR_PEN: number;  // penalty per enemy near a ghost
   INTERCEPT_BASE: number;       // base utility for intercept tasks
   INTERCEPT_DIST_PEN: number;   // extra distance penalty for intercept
+  CARRY_BASE: number;           // base utility for carry tasks
+  CARRY_ENEMY_NEAR_PEN: number; // penalty per enemy near carrier
   DEFEND_BASE: number;          // base utility for defend tasks
   DEFEND_NEAR_BONUS: number;    // extra bonus if threat near base
   BLOCK_BASE: number;           // base utility for blocker tasks
@@ -52,6 +54,8 @@ export const WEIGHTS: Weights = {
   BUST_ENEMY_NEAR_PEN: 6,
   INTERCEPT_BASE: 16,
   INTERCEPT_DIST_PEN: 0.006268810020792386,
+  CARRY_BASE: 15,
+  CARRY_ENEMY_NEAR_PEN: 6,
   DEFEND_BASE: 10,
   DEFEND_NEAR_BONUS: 4,
   BLOCK_BASE: 5,


### PR DESCRIPTION
## Summary
- add `CARRY` task type with risk-aware scoring and base approach waypoints
- consider carry tasks in assignment and action generation (move/release/stun)
- test that carriers receive carry tasks and can switch roles

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a824f4d0d8832bae067bd1b4a90f9e