### PR TITLE
feat: add carry task handling

### DIFF
--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -29,6 +29,8 @@ export type Weights = {
   EXPLORE_BASE: number;         // base utility for explore tasks
   SUPPORT_BASE: number;         // base utility for support tasks
   DIST_PEN: number;             // generic distance penalty
+  CARRY_BASE: number;           // base utility for carry tasks
+  CARRY_ENEMY_NEAR_PEN: number; // penalty per enemy near carrier path
 };
 
 // -----------------------------------------------------------------------------
@@ -58,6 +60,8 @@ export const WEIGHTS: Weights = {
   EXPLORE_BASE: 3,
   SUPPORT_BASE: 8,
   DIST_PEN: 0.0024519620026867764,
+  CARRY_BASE: 14,
+  CARRY_ENEMY_NEAR_PEN: 5,
 };
 
 // Default export (some loaders import default)


### PR DESCRIPTION
## Summary
- assign CARRY tasks for ghost carriers and score based on distance and enemy risk
- support MOVE/RELEASE/STUN candidates for carry assignments
- add tests covering carry task generation and reassignment

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8270512fc832bae5fc502b775f18c