### PR TITLE
chore: remove evolve scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "sim": "pnpm -C packages/sim-runner start",
-    "train": "pnpm -C packages/evolve start",
-    "compile-bot": "pnpm -C packages/evolve compile",
     "make:cg": "tsx scripts/export-cg-bot.ts",
     "tourney:smoke": "pnpm -C packages/sim-runner start tourney --bots greedy,random,evolved --seeds 20 --save-dir ../../viewer/public/replays/tourney",
     "viewer": "pnpm -C packages/viewer dev",


### PR DESCRIPTION
## Summary
- remove unused evolve train and compile-bot scripts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a840fe12cc832ba80b350eb67187bf