### PR TITLE
refactor: use shared move speed

### DIFF
--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -1,11 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta } from './micro';
+import { RULES } from '@busters/shared';
 
 // Verify contested bust uses projected positions
-const STUN = 1760;
-const BUST_MIN = 900;
-const BUST_MAX = 1760;
+const STUN = RULES.STUN_RANGE;
+const BUST_MIN = RULES.BUST_MIN;
+const BUST_MAX = RULES.BUST_MAX;
 
 test('contested bust projects one turn ahead', () => {
   const me = { id: 1, x: 2000, y: 0 };

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -1,10 +1,12 @@
 /** Tiny, fast "micro-rollout" heuristics used inside assignment scores. */
 /** No external deps; keep everything numerically cheap. */
 
+import { RULES } from "@busters/shared";
+
+const SPEED = RULES.MOVE_SPEED; // buster speed per turn
+
 type Pt = { x: number; y: number };
 type Ent = { id: number; x: number; y: number; state?: number; range?: number };
-
-const SPEED = 800; // buster speed per turn
 
 function dist(ax: number, ay: number, bx: number, by: number) {
   return Math.hypot(ax - bx, ay - by);

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -16,6 +16,9 @@
     "./hybrid-bot": "./hybrid-bot.ts",
     "./hof": "./hof.ts"
   },
+  "dependencies": {
+    "@busters/shared": "workspace:*"
+  },
   "devDependencies": {
     "esbuild": "^0.25.9",
     "tsx": "^4.20.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,10 @@ importers:
         version: 5.9.2
 
   packages/agents:
+    dependencies:
+      '@busters/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       esbuild:
         specifier: ^0.25.9


### PR DESCRIPTION
## Summary
- use RULES.MOVE_SPEED from `@busters/shared` in micro heuristics
- update micro tests to leverage shared rule constants
- declare `@busters/shared` dependency in agents package

## Testing
- `pnpm test`
- `cd packages/agents && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8412137dc832b89f81b879575f4d3