### PR TITLE
refactor: reuse shared vector helpers

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -16,6 +16,9 @@
     "./hybrid-bot": "./hybrid-bot.ts",
     "./hof": "./hof.ts"
   },
+  "dependencies": {
+    "@busters/shared": "workspace:*"
+  },
   "devDependencies": {
     "esbuild": "^0.25.9",
     "tsx": "^4.20.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,10 @@ importers:
         version: 5.9.2
 
   packages/agents:
+    dependencies:
+      '@busters/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       esbuild:
         specifier: ^0.25.9


### PR DESCRIPTION
## Summary
- import clamp, dist, and norm from `@busters/shared`
- remove duplicate helper implementations in `hybrid-bot`
- declare `@busters/shared` dependency for agents package

## Testing
- `pnpm --filter @busters/agents test`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84142d66c832b91497bf0ddab0bfd