### PR TITLE
feat: predict enemy paths for better interception

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -176,3 +176,17 @@ test('carrier can switch to higher-scoring task', () => {
   const myTask = assigned.get(1)!;
   assert.equal(myTask.type, 'DEFEND');
 });
+
+test('buildTasks uses predicted path for unseen carriers', () => {
+  const ctx: any = { tick: 3, myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } };
+  const self: any = { id: 1, x: 0, y: 0, state: 0 };
+  const obs: any = { tick: 3, self, friends: [], enemies: [], ghostsVisible: [] };
+  const st = new HybridState();
+  st.trackEnemies([{ id: 2, x: 2600, y: 1000, carrying: 1 }], 1);
+  st.trackEnemies([{ id: 2, x: 1800, y: 1000, carrying: 1 }], 2);
+  st.updateRoles([self]);
+  const tasks = __buildTasks(ctx, obs, st, ctx.myBase, ctx.enemyBase);
+  const intercepts = tasks.filter(t => t.type === 'INTERCEPT' && t.payload?.enemyId === 2);
+  assert.ok(intercepts.some(t => t.target.x === 500 && t.target.y === 500));
+  assert.ok(intercepts.length >= 2);
+});

--- a/packages/agents/state.test.ts
+++ b/packages/agents/state.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { HybridState, predictEnemyPath } from './lib/state';
+
+test('trackEnemies records velocity and last two positions', () => {
+  const st = new HybridState();
+  st.trackEnemies([{ id: 1, x: 2600, y: 1000, carrying: 1 }], 1);
+  st.trackEnemies([{ id: 1, x: 1800, y: 1000, carrying: 1 }], 2);
+  const e = st.enemies.get(1)!;
+  assert.deepEqual(e.prev, { x: 2600, y: 1000 });
+  assert.deepEqual(e.last, { x: 1800, y: 1000 });
+  assert.ok(Math.abs((e.vel?.x ?? 0) + 800) < 1e-6);
+});
+
+test('predictEnemyPath extrapolates toward base', () => {
+  const st = new HybridState();
+  st.trackEnemies([{ id: 1, x: 2600, y: 1000, carrying: 1 }], 1);
+  st.trackEnemies([{ id: 1, x: 1800, y: 1000, carrying: 1 }], 2);
+  const e = st.enemies.get(1)!;
+  const path = predictEnemyPath(e, { x: 0, y: 0 }, 2);
+  assert.deepEqual(path[0], { x: 1000, y: 1000 });
+  assert.deepEqual(path[1], { x: 200, y: 1000 });
+});
+


### PR DESCRIPTION
## Summary
- track enemies with velocity and previous positions
- add helper to forecast unseen carrier positions
- intercept lost carriers along predicted routes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a845cc6c5c832b922e6ca46321f2f6