### PR TITLE
Use global performance for micro heuristics

### DIFF
--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -2,7 +2,8 @@
 /** No external deps; keep everything numerically cheap. */
 
 import { RULES } from "@busters/shared";
-import { performance } from "perf_hooks";
+
+const { performance } = globalThis;
 
 export const microPerf = { twoTurnMs: 0, twoTurnCalls: 0 };
 export const MICRO_BUDGET_MS = 0.5;


### PR DESCRIPTION
## Summary
- avoid Node perf_hooks in agents micro heuristics by using global performance

## Testing
- `pnpm test`
- `pnpm --filter @busters/agents build:cg`


------
https://chatgpt.com/codex/tasks/task_e_68a84f832988832b85b3d3a6a39b1c66