### PR TITLE
Bias explore task selection with fog probabilities

### DIFF
--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -69,7 +69,7 @@ export class Fog {
     this.normalize();
   }
 
-  /** Clear vision circle (approx) by setting heat low & refresh visited in the disk */
+ /** Clear vision circle (approx) by setting heat low & refresh visited in the disk */
   clearCircle(p: Pt, r: number) {
     const gx0 = clamp(Math.floor((p.x - r) / CELL), 0, GX - 1);
     const gx1 = clamp(Math.floor((p.x + r) / CELL), 0, GX - 1);
@@ -89,6 +89,12 @@ export class Fog {
       }
     }
     this.normalize();
+  }
+
+  /** Probability/heat at a given point */
+  probAt(p: Pt): number {
+    const i = this.idxOf(p.x, p.y);
+    return this.heat[i];
   }
 
   /** Positive evidence: increase belief near a ghost sighting */

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -231,6 +231,9 @@ function buildTasks(ctx: Ctx, meObs: Obs, state: HybridState, MY: Pt, EN: Pt): T
       target = path[wp];
       payload.wp = wp;
     }
+    // bias toward high-probability / stale cells from fog
+    const prob = fog.probAt(target!);
+    baseScore += prob * 100;
     // Role bias: scouts favor exploring
     if (state.roleOf(mate.id) === "SCOUT") baseScore += 5;
     tasks.push({ type: "EXPLORE", target: target!, payload, baseScore });
@@ -395,6 +398,7 @@ function runAuction(team: Ent[], tasks: Task[], enemies: Ent[], MY: Pt, tick: nu
 export const __runAuction = runAuction;
 export const __scoreAssign = scoreAssign;
 export const __buildTasks = buildTasks;
+export const __fog = fog;
 
 /** --- Main per-buster policy --- */
 export function act(ctx: Ctx, obs: Obs) {


### PR DESCRIPTION
## Summary
- incorporate fog cell probabilities into EXPLORE task base score
- expose fog instance for tests
- test explore task score responds to fog heat

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84f2e75a0832b937cff6dfa76d75b