### PR TITLE
feat: refine intercept and eject micro heuristics

### DIFF
--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -12,6 +12,9 @@ import {
   releaseBlockDelta,
   twoTurnContestDelta,
   ejectDelta,
+  interceptDelta,
+  twoTurnInterceptDelta,
+  twoTurnEjectDelta,
   scoreCandidate,
   resetMicroPerf,
   microPerf,
@@ -257,15 +260,15 @@ function scoreAssign(b: Ent, t: Task, enemies: Ent[], MY: Pt, tick: number, stat
       const d = dist(b.x, b.y, P.x, P.y);
       s = t.baseScore - d * WEIGHTS.DIST_PEN - d * WEIGHTS.INTERCEPT_DIST_PEN;
       s += duelStunDelta({ me: b, enemy, canStunMe, canStunEnemy: enemy.state !== 2, stunRange: TUNE.STUN_RANGE });
+      s += interceptDelta({ me: b, enemy, myBase: MY });
       s += releaseBlockDelta({ blocker: b, carrier: enemy, myBase: MY, stunRange: TUNE.STUN_RANGE });
       const near = (enemy.range ?? dist(b.x, b.y, enemy.x, enemy.y)) <= 2500;
       const threat = enemy.state === 1 && dist(enemy.x, enemy.y, MY.x, MY.y) <= TUNE.RELEASE_DIST + 2000;
       if ((near || threat) && !microOverBudget()) {
-        s += twoTurnContestDelta({
+        s += twoTurnInterceptDelta({
           me: b,
           enemy,
-          bustMin: BUST_MIN,
-          bustMax: BUST_MAX,
+          myBase: MY,
           stunRange: TUNE.STUN_RANGE,
           canStunMe,
           canStunEnemy: enemy.state !== 2,
@@ -531,10 +534,24 @@ export function act(ctx: Ctx, obs: Obs) {
       const [dx, dy] = norm(target.x - me.x, target.y - me.y);
       const tx = clamp(me.x + dx * EJECT_MAX, 0, W);
       const ty = clamp(me.y + dy * EJECT_MAX, 0, H);
+      const enemy = enemiesAll[0];
+      const deltas = [ejectDelta({ me, target: { x: tx, y: ty }, myBase: MY, ally })];
+      if (enemy && !microOverBudget()) {
+        deltas.push(
+          twoTurnEjectDelta({
+            me,
+            enemy,
+            target: { x: tx, y: ty },
+            myBase: MY,
+            stunRange: TUNE.STUN_RANGE,
+            canStunEnemy: enemy.state !== 2,
+          })
+        );
+      }
       candidates.push({
         act: { type: "EJECT", x: tx, y: ty },
         base: 95,
-        deltas: [ejectDelta({ me, target: { x: tx, y: ty }, myBase: MY, ally })],
+        deltas,
         tag: "EJECT",
         reason: ally ? "handoff" : "base",
       });
@@ -671,6 +688,7 @@ export function act(ctx: Ctx, obs: Obs) {
         const sim = { id: me.id, x: P.x, y: P.y } as Ent;
         const deltas: number[] = [];
         if (enemy) {
+          deltas.push(interceptDelta({ me: sim, enemy, myBase: MY }));
           deltas.push(
             releaseBlockDelta({ blocker: sim, carrier: enemy, myBase: MY, stunRange: TUNE.STUN_RANGE })
           );
@@ -678,11 +696,10 @@ export function act(ctx: Ctx, obs: Obs) {
           const threat = enemy.state === 1 && dist(enemy.x, enemy.y, MY.x, MY.y) <= TUNE.RELEASE_DIST + 2000;
           if ((near || threat) && !microOverBudget()) {
             deltas.push(
-              twoTurnContestDelta({
+              twoTurnInterceptDelta({
                 me: sim,
                 enemy,
-                bustMin: BUST_MIN,
-                bustMax: BUST_MAX,
+                myBase: MY,
                 stunRange: TUNE.STUN_RANGE,
                 canStunMe: canStun,
                 canStunEnemy: enemy.state !== 2,
@@ -702,11 +719,10 @@ export function act(ctx: Ctx, obs: Obs) {
           stunRange: TUNE.STUN_RANGE,
         });
         if (!microOverBudget()) {
-          delta += twoTurnContestDelta({
+          delta += twoTurnInterceptDelta({
             me,
             enemy,
-            bustMin: BUST_MIN,
-            bustMax: BUST_MAX,
+            myBase: MY,
             stunRange: TUNE.STUN_RANGE,
             canStunMe: true,
             canStunEnemy: enemy.state !== 2,

--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta } from './micro';
+import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta, interceptDelta, twoTurnInterceptDelta, twoTurnEjectDelta } from './micro';
 import { RULES } from '@busters/shared';
 
 // Verify contested bust uses projected positions
@@ -114,4 +114,46 @@ test('ejectDelta favors progress and ally handoff', () => {
   const ally = { id: 2, x: 3300, y: 3300 };
   const delta = ejectDelta({ me, target, myBase, ally });
   assert.ok(delta > 0);
+});
+
+test('interceptDelta rewards beating enemy to intercept', () => {
+  const me = { id: 1, x: 3000, y: 0 };
+  const enemy = { id: 2, x: 6000, y: 0 };
+  const myBase = { x: 0, y: 0 };
+  const delta = interceptDelta({ me, enemy, myBase });
+  assert.ok(delta > 0);
+  const second = twoTurnInterceptDelta({
+    me,
+    enemy,
+    myBase,
+    stunRange: STUN,
+    canStunMe: true,
+    canStunEnemy: false,
+  });
+  assert.ok(second > delta);
+});
+
+test('twoTurnEjectDelta penalizes enemy near landing', () => {
+  const me = { id: 1, x: 4000, y: 4000 };
+  const target = { x: 3500, y: 3500 };
+  const myBase = { x: 0, y: 0 };
+  const farEnemy = { id: 2, x: 7000, y: 7000 };
+  const nearEnemy = { id: 3, x: 3600, y: 3600 };
+  const safe = twoTurnEjectDelta({
+    me,
+    enemy: farEnemy,
+    target,
+    myBase,
+    stunRange: STUN,
+    canStunEnemy: true,
+  });
+  const risky = twoTurnEjectDelta({
+    me,
+    enemy: nearEnemy,
+    target,
+    myBase,
+    stunRange: STUN,
+    canStunEnemy: true,
+  });
+  assert.ok(risky < safe);
 });


### PR DESCRIPTION
## Summary
- add intercept and eject helper heuristics with two-turn lookahead
- call new deltas from hybrid-bot when evaluating intercepts or ejections
- expand micro timing budget tracking and cover with tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84f30575c832bb78f464145c5ae73