### PR TITLE
Track corridor probabilities for unseen carriers

### DIFF
--- a/packages/agents/fog.test.ts
+++ b/packages/agents/fog.test.ts
@@ -2,6 +2,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Fog } from './fog';
 
+test('constructor seeds heat at spawn points', () => {
+  const f = new Fog([{ x: 0, y: 0 }]);
+  const idx = (f as any).idxOf(0, 0);
+  const h = (f as any).heat[idx];
+  assert.ok(h > 0);
+});
+
 test('bumpGhost raises heat and beginTick decays it', () => {
   const f = new Fog();
   f.bumpGhost(8000, 4500);
@@ -52,4 +59,20 @@ test('pickFrontierTarget favors hot unvisited cells', () => {
   const target = f.pickFrontierTarget({ x: 0, y: 0 });
   assert.ok(Math.abs(target.x - 8200) < 400);
   assert.ok(Math.abs(target.y - 4600) < 400);
+});
+
+test('bumpCorridor increases corridor probability and decays', () => {
+  const f = new Fog();
+  const path = [
+    { x: 0, y: 0 },
+    { x: 8000, y: 4500 },
+    { x: 16000, y: 9000 }
+  ];
+  f.bumpCorridor(path);
+  const idx = (f as any).idxOf(8000, 4500);
+  const c0 = (f as any).corridor[idx];
+  assert.ok(c0 > 0);
+  f.beginTick(1);
+  const c1 = (f as any).corridor[idx];
+  assert.ok(c1 < c0);
 });

--- a/packages/agents/fog.ts
+++ b/packages/agents/fog.ts
@@ -2,6 +2,7 @@
  *  - Grid covers 16000x9000 with 400px cells => 40 x 23
  *  - Tracks last-visited tick per cell
  *  - Tracks a soft "ghost belief" heat value per cell (decays each tick)
+ *  - Tracks probability corridors for unseen enemy carriers
  *  - Provides pickFrontierTarget(start) = best exploration target
  *
  *  API:
@@ -29,17 +30,30 @@ export class Fog {
   private last: Int32Array;
   // belief heat (0..+inf, small decay)
   private heat: Float32Array;
+  // corridor probability for unseen carriers
+  private corridor: Float32Array;
 
-  constructor() {
+  private ghostDecay: number;
+  private corridorDecay: number;
+  private spawns: Pt[];
+
+  constructor(spawnPoints: Pt[] = [], ghostDecay = 0.97, corridorDecay = 0.9) {
     this.last = new Int32Array(GX * GY);
     this.heat = new Float32Array(GX * GY);
+    this.corridor = new Float32Array(GX * GY);
+    this.ghostDecay = ghostDecay;
+    this.corridorDecay = corridorDecay;
+    this.spawns = spawnPoints.slice();
     for (let i = 0; i < this.last.length; i++) this.last[i] = -1;
+    this.seedSpawns();
   }
 
   reset() {
     this.tick = 0;
     this.last.fill(-1);
     this.heat.fill(0);
+    this.corridor.fill(0);
+    this.seedSpawns();
   }
 
   beginTick(t: number) {
@@ -47,10 +61,11 @@ export class Fog {
     this.tick = t;
 
     // light decay of heat to slowly forget stale beliefs
-    // (fast: vectorized loop)
     for (let i = 0; i < this.heat.length; i++) {
-      this.heat[i] *= 0.97; // gentle decay
+      this.heat[i] *= this.ghostDecay;
       if (this.heat[i] < 0.02) this.heat[i] = 0;
+      this.corridor[i] *= this.corridorDecay;
+      if (this.corridor[i] < 0.02) this.corridor[i] = 0;
     }
     this.diffuse();
     this.normalize();
@@ -66,7 +81,9 @@ export class Fog {
     const i = this.idxOf(p.x, p.y);
     this.last[i] = this.tick;
     this.heat[i] *= 0.5;
+    this.corridor[i] *= 0.5;
     this.normalize();
+    this.normalizeCorridor();
   }
 
   /** Clear vision circle (approx) by setting heat low & refresh visited in the disk */
@@ -85,10 +102,12 @@ export class Fog {
           const i = gy * GX + gx;
           this.last[i] = this.tick;
           this.heat[i] *= 0.2; // strong down-weight if we just saw it
+          this.corridor[i] *= 0.2;
         }
       }
     }
     this.normalize();
+    this.normalizeCorridor();
   }
 
   /** Positive evidence: increase belief near a ghost sighting */
@@ -109,6 +128,15 @@ export class Fog {
       }
     }
     this.normalize();
+  }
+
+  /** Track corridor probability along a path of points (unseen carrier) */
+  bumpCorridor(path: Pt[]) {
+    for (const p of path) {
+      const i = this.idxOf(p.x, p.y);
+      this.corridor[i] += 1;
+    }
+    this.normalizeCorridor();
   }
 
   private diffuse() {
@@ -143,6 +171,23 @@ export class Fog {
     for (const v of this.heat) sum += v;
     if (sum <= 0) return;
     for (let i = 0; i < this.heat.length; i++) this.heat[i] /= sum;
+  }
+
+  private normalizeCorridor() {
+    let sum = 0;
+    for (const v of this.corridor) sum += v;
+    if (sum <= 0) return;
+    for (let i = 0; i < this.corridor.length; i++) this.corridor[i] /= sum;
+  }
+
+  /** Seed initial ghost belief at spawn points */
+  private seedSpawns() {
+    if (!this.spawns.length) return;
+    for (const s of this.spawns) {
+      const i = this.idxOf(s.x, s.y);
+      this.heat[i] += 1;
+    }
+    this.normalize();
   }
 
   /** Frontier score and target based on age * distance * heat */

--- a/packages/agents/state.test.ts
+++ b/packages/agents/state.test.ts
@@ -22,3 +22,18 @@ test('predictEnemyPath extrapolates toward base', () => {
   assert.deepEqual(path[1], { x: 200, y: 1000 });
 });
 
+test('updateCorridors tracks unseen carrier path and decays', () => {
+  const st = new HybridState();
+  st.trackEnemies([{ id: 1, x: 2600, y: 1000, carrying: 1 }], 1);
+  const e = st.enemies.get(1)!;
+  const base = { x: 0, y: 0 };
+  const path = predictEnemyPath(e, base, 10);
+  st.updateCorridors(base);
+  const p = path[0];
+  const before = st.corridorProbAt(p);
+  assert.ok(before > 0);
+  st.decayCorridors();
+  const after = st.corridorProbAt(p);
+  assert.ok(after < before);
+});
+


### PR DESCRIPTION
## Summary
- Track corridor probabilities for unseen enemy carriers in fog and shared state
- Seed ghost belief maps with spawn coordinates and decay over time
- Add unit tests covering spawn seeding and corridor updates

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84f6a83c4832bbe333351a9c07fc9