### PR TITLE
Add export checklist and Codingame bot smoke test

### DIFF
--- a/docs/EVOL2.md
+++ b/docs/EVOL2.md
@@ -280,6 +280,16 @@ pnpm cg:export:champ
 ```
 Copy the resulting `agents/codingame-bot.js` into the CodinGame IDE to deploy.
 
+### Export Checklist
+
+1. Run the exporter (`pnpm cg:export:hybrid` or `pnpm cg:export:genome`).
+2. Smoke test the generated bot locally:
+   ```bash
+   node codingame_bot.js <<<'2 0 0\n0'
+   ```
+   It should immediately print one line per buster and exit when killed.
+3. Paste `agents/codingame-bot.js` into the CodinGame IDE.
+
 ## Testing, Evaluation & Robustness
 - Unit-test scoring, candidate generation, and micro-sim with synthetic states.
 - Deterministic seeds; CRN per matchup; regression tests on fixed episodes.

--- a/packages/agents/export-codingame.test.ts
+++ b/packages/agents/export-codingame.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..', '..');
+const outFile = path.join(root, 'codingame_bot.js');
+
+test('exported bot runs under codingame_bot.js', () => {
+  // export using current hybrid parameters
+  execSync(`pnpm exec tsx scripts/export-codingame.ts --from hybrid --out ${outFile}`, { cwd: root, stdio: 'inherit' });
+
+  try {
+    const code = fs.readFileSync(outFile, 'utf8');
+    const inputs = ['2', '0', '0', '0'];
+    const outputs: string[] = [];
+    vm.runInNewContext(code, {
+      readline: () => inputs.shift(),
+      print: (s: string) => outputs.push(String(s))
+    });
+    assert.equal(outputs.length, 2, 'expected two action lines');
+  } finally {
+    if (fs.existsSync(outFile)) fs.unlinkSync(outFile);
+  }
+});


### PR DESCRIPTION
## Summary
- document explicit checklist for exporting Codingame bot
- add smoke test ensuring exported bot runs under `codingame_bot.js`

## Testing
- `pnpm test`
- `pnpm exec tsx scripts/export-codingame.ts --from hybrid --out codingame_bot.js`

------
https://chatgpt.com/codex/tasks/task_e_68a852701350832bac8d6e3864b817cc