### PR TITLE
feat: add base camper and aggressive stunner bots

### DIFF
--- a/packages/agents/aggressive-stunner.js
+++ b/packages/agents/aggressive-stunner.js
@@ -1,0 +1,39 @@
+export const meta = { name: "aggressive-stunner", version: "1.0" };
+
+/**
+ * Hunts enemies across the map to chain stuns.
+ * Falls back to busting nearby ghosts when no enemies are seen.
+ */
+export function act(ctx, obs) {
+  const me = obs.self;
+
+  // If carrying, head home
+  if (me.carrying !== undefined) {
+    const d = Math.hypot(me.x - ctx.myBase.x, me.y - ctx.myBase.y);
+    if (d <= 1500) return { type: "RELEASE" };
+    return { type: "MOVE", x: ctx.myBase.x, y: ctx.myBase.y };
+  }
+
+  // Chase enemies aggressively
+  const enemy = (obs.enemies || [])
+    .map(e => ({ e, d: Math.hypot(me.x - e.x, me.y - e.y) }))
+    .sort((a, b) => a.d - b.d)[0];
+  if (enemy) {
+    if (enemy.d <= 1760 && me.stunCd <= 0) {
+      return { type: "STUN", busterId: enemy.e.id };
+    }
+    return { type: "MOVE", x: enemy.e.x, y: enemy.e.y };
+  }
+
+  // Ghost fallback
+  const g = (obs.ghostsVisible || [])
+    .map(g => ({ g, d: Math.hypot(me.x - g.x, me.y - g.y) }))
+    .sort((a, b) => a.d - b.d)[0];
+  if (g) {
+    if (g.d >= 900 && g.d <= 1760) return { type: "BUST", ghostId: g.g.id };
+    return { type: "MOVE", x: g.g.x, y: g.g.y };
+  }
+
+  // Otherwise drift toward center
+  return { type: "MOVE", x: 8000, y: 4500 };
+}

--- a/packages/agents/base-camper.js
+++ b/packages/agents/base-camper.js
@@ -1,0 +1,28 @@
+export const meta = { name: "base-camper", version: "1.0" };
+
+/**
+ * Simple base camper: rushes enemy base and waits to stun carriers.
+ * Ignores ghosts unless carrying a ghost home.
+ */
+export function act(ctx, obs) {
+  const me = obs.self;
+  const enemyBase = ctx.myTeamId === 0 ? { x:16000, y:9000 } : { x:0, y:0 };
+
+  // If carrying, return home and release near base
+  if (me.carrying !== undefined) {
+    const d = Math.hypot(me.x - ctx.myBase.x, me.y - ctx.myBase.y);
+    if (d <= 1500) return { type: "RELEASE" };
+    return { type: "MOVE", x: ctx.myBase.x, y: ctx.myBase.y };
+  }
+
+  // Stun enemies that get too close
+  const enemy = (obs.enemies || [])
+    .map(e => ({ e, d: Math.hypot(me.x - e.x, me.y - e.y) }))
+    .sort((a, b) => a.d - b.d)[0];
+  if (enemy && enemy.d <= 1760 && me.stunCd <= 0) {
+    return { type: "STUN", busterId: enemy.e.id };
+  }
+
+  // Default: camp the enemy base
+  return { type: "MOVE", x: enemyBase.x, y: enemyBase.y };
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -9,6 +9,8 @@
     "./evolved": "./evolved-bot.js",
     "./camper": "./camper-stunner.js",
     "./stunner": "./aggro-chaser.js",
+    "./base-camper": "./base-camper.js",
+    "./aggressive-stunner": "./aggressive-stunner.js",
     "./defender": "./defender-bot.ts",
     "./scout": "./scout-bot.ts",
     "./hybrid": "./hybrid-bot.ts",

--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -476,7 +476,7 @@ async function main() {
     const seedsPer = Number(getFlag(rest, 'seeds-per', 7));
     const episodesPerSeed = Number(getFlag(rest, 'eps-per-seed', 3));
     const jobs = Number(getFlag(rest, 'jobs', 1)); // reserved
-    const oppPoolArg = String(getFlag(rest, 'opp-pool', 'greedy,random,stunner,camper,defender,scout,hof'));
+    const oppPoolArg = String(getFlag(rest, 'opp-pool', 'greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner,hof'));
     const subject = String(getFlag(rest, 'subject', '')).trim().toLowerCase();
     const pfsp = getBool(rest, 'pfsp', false);
     const pfspCount = Number(getFlag(rest, 'pfsp-count', 3));
@@ -521,7 +521,7 @@ async function main() {
     }
 
     console.log(`Unknown or empty --subject. Use: --subject hybrid`);
-    console.log(`Example:\n  tsx src/cli.ts train --subject hybrid --algo cma --pop 16 --gens 4 --seeds-per 5 --eps-per-seed 2 --seed 99 --opp-pool greedy,stunner,camper,random,defender,scout,hof`);
+    console.log(`Example:\n  tsx src/cli.ts train --subject hybrid --algo cma --pop 16 --gens 4 --seeds-per 5 --eps-per-seed 2 --seed 99 --opp-pool greedy,stunner,camper,random,defender,scout,base-camper,aggressive-stunner,hof`);
     return;
   }
 
@@ -623,7 +623,7 @@ async function main() {
 
   console.log(`Usage:
   # Train Hybrid (CEM)
-  tsx src/cli.ts train --subject hybrid --algo cem --pop 24 --gens 12 --seeds-per 7 --seed 42 --opp-pool greedy,random,stunner,camper,defender,scout,hof [--pfsp]
+  tsx src/cli.ts train --subject hybrid --algo cem --pop 24 --gens 12 --seeds-per 7 --seed 42 --opp-pool greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner,hof [--pfsp]
 
   # Sim a single match (save replay with actions & tags)
   tsx src/cli.ts sim <botA> <botB> [--episodes 3] [--seed 42] [--replay path.json]

--- a/packages/sim-runner/src/ga.ts
+++ b/packages/sim-runner/src/ga.ts
@@ -52,6 +52,8 @@ const DEFAULT_MODULE = '@busters/agents/greedy';
     random: '@busters/agents/random',
     camper: '@busters/agents/camper',
     stunner: '@busters/agents/stunner',
+    'base-camper': '@busters/agents/base-camper',
+    'aggressive-stunner': '@busters/agents/aggressive-stunner',
     defender: '@busters/agents/defender',
     scout: '@busters/agents/scout',
   };

--- a/packages/sim-runner/src/loadBots.ts
+++ b/packages/sim-runner/src/loadBots.ts
@@ -12,6 +12,8 @@ const ALIASES: Record<string, string> = {
   greedy: "@busters/agents/greedy",
   stunner: "@busters/agents/stunner",
   camper: "@busters/agents/camper",
+  "base-camper": "@busters/agents/base-camper",
+  "aggressive-stunner": "@busters/agents/aggressive-stunner",
   random: "@busters/agents/random",
   defender: "@busters/agents/defender",
   scout: "@busters/agents/scout",


### PR DESCRIPTION
## Summary
- add simple base-camper and aggressive-stunner agents
- expose new agents through sim-runner and CLI opponent pool

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8571ab148832bba3be9d4beccb21f