### PR TITLE
Simplify sim-runner opponent pool and cover alias bots

### DIFF
--- a/packages/sim-runner/package.json
+++ b/packages/sim-runner/package.json
@@ -15,6 +15,7 @@
     "tsx": "^4.16.2"
   },
   "scripts": {
-    "start": "tsx src/cli.ts"
+    "start": "tsx src/cli.ts",
+    "test": "tsx --test src/*.test.ts"
   }
 }

--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -48,24 +48,14 @@ function gaussian(rng: () => number) {
 function clamp(v: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, v)); }
 
 /* ---------------- Opponent pool ---------------- */
-async function resolveOppPool(specList: string[]): Promise<Array<{name: string, bot: any}>> {
-  const mapNameToSpec = (n: string) => {
-    const k = n.trim();
-    if (k === 'greedy')  return '@busters/agents/greedy';
-    if (k === 'random')  return '@busters/agents/random';
-    if (k === 'stunner') return '@busters/agents/stunner';
-    if (k === 'camper')  return '@busters/agents/camper';
-    if (k === 'defender') return '@busters/agents/defender';
-    if (k === 'scout')    return '@busters/agents/scout';
-    if (k === 'hybrid')  return '@busters/agents/hybrid';
-    if (k === 'hof')     return '@busters/agents/hof';
-    return k; // assume direct spec
-  };
-  const out: Array<{name: string, bot: any}> = [];
-  for (const n of specList) {
-    const spec = mapNameToSpec(n);
-    const bot = await loadBotModule(spec);
-    out.push({ name: n, bot });
+export async function resolveOppPool(
+  specList: string[]
+): Promise<Array<{ name: string; bot: any }>> {
+  const out: Array<{ name: string; bot: any }> = [];
+  for (const raw of specList) {
+    const name = raw.trim();
+    const bot = await loadBotModule(name);
+    out.push({ name, bot });
   }
   return out;
 }

--- a/packages/sim-runner/src/resolveOppPool.test.ts
+++ b/packages/sim-runner/src/resolveOppPool.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveOppPool } from './cli';
+
+async function getNames(tokens: string[]) {
+  const res = await resolveOppPool(tokens);
+  return res.map(r => r.bot.meta?.name);
+}
+
+test('resolveOppPool loads base-camper', async () => {
+  const names = await getNames(['base-camper']);
+  assert.deepEqual(names, ['base-camper']);
+});
+
+test('resolveOppPool loads aggressive-stunner', async () => {
+  const names = await getNames(['aggressive-stunner']);
+  assert.deepEqual(names, ['aggressive-stunner']);
+});


### PR DESCRIPTION
## Summary
- resolve opponents via `loadBotModule` to leverage centralized alias mapping
- add unit tests for `base-camper` and `aggressive-stunner` tokens
- wire up sim-runner test script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a85a7eeaec832b9e8f205d96325888