### PR TITLE
centralize bot aliases in sim-runner

### DIFF
--- a/docs/EVOL2.md
+++ b/docs/EVOL2.md
@@ -231,6 +231,7 @@ def assign_greedy_improved(scores, spacing_penalty) {
 
 ## Training Flow (`packages/sim-runner`)
 The `sim-runner` package drives evolutionary training and evaluation.
+Available bot aliases are centralized in `packages/sim-runner/src/loadBots.ts` as `BOT_ALIASES`.
 
 ### CEM Training
 ```bash

--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -1,7 +1,7 @@
 // packages/sim-runner/src/cli.ts
 import fs from 'fs';
 import path from 'path';
-import { loadBotModule } from './loadBots';
+import { loadBotModule, BOT_ALIASES } from './loadBots';
 import { runEpisodes } from './runEpisodes';
 import { runRoundRobin } from './tournament';
 import { trainCEM } from './ga';
@@ -17,6 +17,8 @@ import {
 
 import { selectOpponentsPFSP } from './pfsp';
 import { loadEloTable, saveEloTable, updateElo } from './elo';
+
+const ALIAS_LIST = Object.keys(BOT_ALIASES).join(',');
 
 /* --------------------- CLI helpers --------------------- */
 function getFlag(args: string[], name: string, def?: any) {
@@ -466,7 +468,7 @@ async function main() {
     const seedsPer = Number(getFlag(rest, 'seeds-per', 7));
     const episodesPerSeed = Number(getFlag(rest, 'eps-per-seed', 3));
     const jobs = Number(getFlag(rest, 'jobs', 1)); // reserved
-    const oppPoolArg = String(getFlag(rest, 'opp-pool', 'greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner,hof'));
+    const oppPoolArg = String(getFlag(rest, 'opp-pool', ALIAS_LIST));
     const subject = String(getFlag(rest, 'subject', '')).trim().toLowerCase();
     const pfsp = getBool(rest, 'pfsp', false);
     const pfspCount = Number(getFlag(rest, 'pfsp-count', 3));
@@ -511,7 +513,7 @@ async function main() {
     }
 
     console.log(`Unknown or empty --subject. Use: --subject hybrid`);
-    console.log(`Example:\n  tsx src/cli.ts train --subject hybrid --algo cma --pop 16 --gens 4 --seeds-per 5 --eps-per-seed 2 --seed 99 --opp-pool greedy,stunner,camper,random,defender,scout,base-camper,aggressive-stunner,hof`);
+    console.log(`Example:\n  tsx src/cli.ts train --subject hybrid --algo cma --pop 16 --gens 4 --seeds-per 5 --eps-per-seed 2 --seed 99 --opp-pool ${ALIAS_LIST}`);
     return;
   }
 
@@ -615,7 +617,7 @@ async function main() {
 
   console.log(`Usage:
   # Train Hybrid (CEM)
-  tsx src/cli.ts train --subject hybrid --algo cem --pop 24 --gens 12 --seeds-per 7 --seed 42 --opp-pool greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner,hof [--pfsp]
+  tsx src/cli.ts train --subject hybrid --algo cem --pop 24 --gens 12 --seeds-per 7 --seed 42 --opp-pool ${ALIAS_LIST} [--pfsp]
 
   # Sim a single match (save replay with actions & tags)
   tsx src/cli.ts sim <botA> <botB> [--episodes 3] [--seed 42] [--replay path.json]

--- a/packages/sim-runner/src/ga.aliases.test.ts
+++ b/packages/sim-runner/src/ga.aliases.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCandidates } from './ga';
+import { BOT_ALIASES } from './loadBots';
+
+test('buildCandidates resolves bot aliases', () => {
+  const cands = buildCandidates([
+    { name: 'base-camper' },
+    { name: 'aggressive-stunner' },
+  ], []);
+  const specs = cands.filter(c => c.type === 'module').map(c => c.spec);
+  assert(specs.includes(BOT_ALIASES['base-camper']));
+  assert(specs.includes(BOT_ALIASES['aggressive-stunner']));
+});

--- a/packages/sim-runner/src/loadBots.ts
+++ b/packages/sim-runner/src/loadBots.ts
@@ -8,7 +8,7 @@ export type Bot = {
 };
 
 // Map short names -> real package export specs
-const ALIASES: Record<string, string> = {
+export const BOT_ALIASES: Record<string, string> = {
   greedy: "@busters/agents/greedy",
   stunner: "@busters/agents/stunner",
   camper: "@busters/agents/camper",
@@ -38,7 +38,7 @@ export function resolveSpec(token: string): string {
   // if already a path or scoped package, keep as-is
   if (token.startsWith("@") || token.startsWith(".") || token.startsWith("/")) return token;
   // else try alias
-  return ALIASES[token] ?? token;
+  return BOT_ALIASES[token] ?? token;
 }
 
 /** Load a bot module by spec or alias */
@@ -49,9 +49,9 @@ export async function loadBotModule(specOrAlias: string): Promise<Bot> {
     mod = await import(spec);
   } catch (e) {
     // Helpful message if the alias was not resolvable
-    const hint = ALIASES[specOrAlias]
+    const hint = BOT_ALIASES[specOrAlias]
       ? `Resolved "${specOrAlias}" -> "${spec}" but import failed. Check @busters/agents/package.json exports and file existence.`
-      : `Unknown bot token "${specOrAlias}". Try one of: ${Object.keys(ALIASES).join(", ")}, or pass a full module path.`;
+      : `Unknown bot token "${specOrAlias}". Try one of: ${Object.keys(BOT_ALIASES).join(", ")}, or pass a full module path.`;
     throw new Error(`${(e as Error).message}\n${hint}`);
   }
 


### PR DESCRIPTION
## Summary
- export BOT_ALIASES from sim-runner loadBots
- reuse BOT_ALIASES in CLI and GA, updating messaging
- add tests for alias handling and document alias location

## Testing
- `pnpm test`
- `pnpm -F @busters/sim-runner test`


------
https://chatgpt.com/codex/tasks/task_e_68a85cd01aa8832b9f500db59d7b27a1