### PR TITLE
Skip support task on long-stunned enemies

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -208,3 +208,18 @@ test('buildTasks uses predicted path for unseen carriers', () => {
   assert.ok(intercepts.some(t => t.target.x === 500 && t.target.y === 500));
   assert.ok(intercepts.length >= 2);
 });
+
+test('buildTasks skips SUPPORT for enemies stunned for several ticks', () => {
+  __mem.clear();
+  const ctx: any = { tick: 0, myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } };
+  const self: any = { id: 1, x: 0, y: 0, state: 0 };
+  const enemy: any = { id: 2, x: 0, y: 0, state: 0, range: 0 };
+  const st = new HybridState();
+  st.updateRoles([self]);
+  let tasks = __buildTasks(ctx, { tick: 0, self, friends: [], enemies: [enemy], ghostsVisible: [] }, st, ctx.myBase, ctx.enemyBase);
+  assert.ok(tasks.some(t => t.type === 'SUPPORT' && t.payload?.enemyId === 2));
+
+  const stunned: any = { id: 2, x: 0, y: 0, state: 2, range: 0, stunnedFor: 5 };
+  tasks = __buildTasks(ctx, { tick: 0, self, friends: [], enemies: [stunned], ghostsVisible: [] }, st, ctx.myBase, ctx.enemyBase);
+  assert.ok(!tasks.some(t => t.type === 'SUPPORT' && t.payload?.enemyId === 2));
+});

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -192,7 +192,7 @@ function buildTasks(ctx: Ctx, meObs: Obs, state: HybridState, MY: Pt, EN: Pt): T
   for (const e of enemies) {
     const alliesNear = team.filter(f => f.id !== e.id && dist(f.x, f.y, e.x, e.y) <= TUNE.STUN_RANGE);
     const ready = alliesNear.some(a => M(a.id).stunReadyAt <= tick);
-    if (alliesNear.length && ready) {
+    if (alliesNear.length && ready && (e.state !== 2 || (e.stunnedFor ?? 0) <= 2)) {
       tasks.push({
         type: "SUPPORT",
         target: { x: e.x, y: e.y },


### PR DESCRIPTION
## Summary
- avoid assigning SUPPORT stun-chain tasks to enemies that are still stunned for several ticks
- test that stunned enemies don't receive SUPPORT tasks

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a862983080832bb8ea0211b5c8220b