### PR TITLE
Use local shared helpers in agents

### DIFF
--- a/packages/agents/defender-bot.ts
+++ b/packages/agents/defender-bot.ts
@@ -1,4 +1,5 @@
-import type { AgentContext, Observation, Action } from '@busters/shared';
+// Type imports from shared package via relative path to avoid resolution issues
+import type { AgentContext, Observation, Action } from '../shared/src/types.ts';
 
 export function act(ctx: AgentContext, obs: Observation): Action {
   const me = obs.self;

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -21,7 +21,8 @@ import {
   microOverBudget,
 } from "./micro";
 import { hungarian } from "./hungarian";
-import { clamp, dist, norm } from "@busters/shared";
+// Import basic vector helpers directly to avoid workspace package resolution issues
+import { clamp, dist, norm } from "../shared/src/vec.ts";
 
 const micro = (fn: () => number) => (microOverBudget() ? 0 : fn());
 

--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -5,7 +5,8 @@
  *  Keep it tiny and robust; we’ll extend later (ghost probs, priors, etc.).
  */
 
-import { RULES } from "@busters/shared";
+// Pull in shared game constants without relying on workspace resolution
+import { RULES } from "../../shared/src/constants.ts";
 
 export type Pt = { x: number; y: number };
 

--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -1,7 +1,7 @@
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta, interceptDelta, twoTurnInterceptDelta, twoTurnEjectDelta, resetMicroPerf, microPerf, microOverBudget, MICRO_BUDGET_MS } from './micro';
-import { RULES } from '@busters/shared';
+import { RULES } from '../shared/src/constants.ts';
 
 // Verify contested bust uses projected positions
 const STUN = RULES.STUN_RANGE;

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -1,7 +1,8 @@
 /** Tiny, fast "micro-rollout" heuristics used inside assignment scores. */
 /** No external deps; keep everything numerically cheap. */
 
-import { RULES } from "@busters/shared";
+// Use shared constants via relative import to avoid package lookup
+import { RULES } from "../shared/src/constants.ts";
 
 const { performance } = globalThis;
 

--- a/packages/agents/scout-bot.ts
+++ b/packages/agents/scout-bot.ts
@@ -1,4 +1,5 @@
-import type { AgentContext, Observation, Action } from '@busters/shared';
+// Import shared types locally to avoid depending on workspace package resolution
+import type { AgentContext, Observation, Action } from '../shared/src/types.ts';
 
 const WAYPOINTS = [
   { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- import vector helpers and constants from the shared source directly in agent modules
- update agent tests to use the new relative imports

## Testing
- `pnpm test`
- `bash scripts/train_long.sh --pop 4 --gens 1 --seeds-per 1 --eps-per-seed 1 --jobs 1 --seed 1 --opp-pool greedy --hof 1 --subject hybrid --tag run`


------
https://chatgpt.com/codex/tasks/task_e_68a86a6cfc78832baf225cab3b32aba6