### PR TITLE
Enforce strict base-release radius across bots

### DIFF
--- a/agents/evolved-bot.cg.js
+++ b/agents/evolved-bot.cg.js
@@ -36,6 +36,7 @@ var __defProp = Object.defineProperty;
   // fog.ts
   var W = 16e3;
   var H = 9e3;
+  var BASE_SCORE_RADIUS = 1600; // must be strictly inside to score
   var CELL = 400;
   var GX = Math.ceil(W / CELL);
   var GY = Math.ceil(H / CELL);
@@ -905,7 +906,8 @@ var __defProp = Object.defineProperty;
     const canStun = !stunned && stunCdLeft <= 0;
     if (carrying) {
       const dHome = dist3(me.x, me.y, MY.x, MY.y);
-      if (dHome <= TUNE2.RELEASE_DIST) {
+      if (dHome < Math.min(TUNE2.RELEASE_DIST, BASE_SCORE_RADIUS)) {
+        // release only when strictly inside base radius
         return dbg({ type: "RELEASE" }, "RELEASE", "at_base");
       }
       const home = spacedTarget(me, MY, friends);

--- a/bot_template_cg.js
+++ b/bot_template_cg.js
@@ -90,10 +90,10 @@ while (true) {
       continue;
     }
 
-    // Carrying → go home & release when close enough (<= BASE_SCORE_RADIUS guarantees scoring)
+    // Carrying → go home & release when strictly inside base (< BASE_SCORE_RADIUS)
     if (me.state === 1) {
       const dHome = dist(me.x, me.y, myBase.x, myBase.y);
-      if (dHome <= Math.min(G.releaseDist, BASE_SCORE_RADIUS)) {
+      if (dHome < Math.min(G.releaseDist, BASE_SCORE_RADIUS)) {
         out.push('RELEASE carry→score');
       } else {
         out.push(`MOVE ${myBase.x} ${myBase.y} carry→home`);

--- a/codingame_bot.js
+++ b/codingame_bot.js
@@ -1,7 +1,7 @@
 // Auto-generated Codingame bot using an evolved genome (no deps).
 const GENOME={radarTurn:1,stunRange:,releaseDist:};
 const WIDTH=16001, HEIGHT=9001, BASE0={x:0,y:0}, BASE1={x:16000,y:9000};
-const BUST_MIN=900, BUST_MAX=1760, STUN_CD_TURNS=20;
+const BUST_MIN=900, BUST_MAX=1760, STUN_CD_TURNS=20, BASE_SCORE_RADIUS=1600;
 const bustersPerPlayer=parseInt(readline(),10);
 const ghostCount=parseInt(readline(),10);
 const myTeamId=parseInt(readline(),10);
@@ -27,7 +27,7 @@ while(true){
     const ne=enemies.map(e=>({e,d:dist(me,e)})).sort((a,b)=>a.d-b.d)[0];
     const ng=ghosts.map(g=>({g,d:dist(me,g)})).sort((a,b)=>a.d-b.d)[0];
     if(me.state===1){
-      if(dBase<=GENOME.releaseDist){ actions.push('RELEASE'); continue; }
+      if(dBase<Math.min(GENOME.releaseDist,BASE_SCORE_RADIUS)){ actions.push('RELEASE'); continue; }
       actions.push(`MOVE ${MY_BASE.x} ${MY_BASE.y}`); continue;
     }
     if(ne && ne.d<=GENOME.stunRange && stunCd.get(me.id)<=0){

--- a/packages/agents/greedy-buster.js
+++ b/packages/agents/greedy-buster.js
@@ -2,7 +2,7 @@
 export function act(ctx, obs) {
   if (obs.self.carrying !== undefined) {
     const dHome = Math.hypot(obs.self.x - ctx.myBase.x, obs.self.y - ctx.myBase.y);
-    if (dHome <= 1400) return { type: 'RELEASE' };
+    if (dHome < 1400) return { type: 'RELEASE' };
     return { type: 'MOVE', x: ctx.myBase.x, y: ctx.myBase.y };
   }
   // Stun nearest enemy if in range and off cooldown

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -35,6 +35,7 @@ const WEIGHTS = WEIGHTS_IN as any;
 
 /** --- Small utils (no imports) --- */
 const W = 16000, H = 9000;
+const BASE_SCORE_RADIUS = 1600; // must be strictly inside to score
 const BUST_MIN = 900, BUST_MAX = 1760;
 const STUN_CD = 20;
 const EJECT_MAX = 1760;
@@ -469,10 +470,10 @@ export function act(ctx: Ctx, obs: Obs) {
 
   /* ---------- High-priority instant actions ---------- */
 
-  // Release if at base
+  // Carrying but not yet inside scoring radius
   if (carrying) {
     const dHome = dist(me.x, me.y, MY.x, MY.y);
-    if (dHome > TUNE.RELEASE_DIST) {
+    if (dHome >= Math.min(TUNE.RELEASE_DIST, BASE_SCORE_RADIUS)) {
       const threat = enemies.find(e => (e.stunnedFor ?? 0) <= 0 && dist(e.x, e.y, me.x, me.y) <= TUNE.STUN_RANGE);
       let handoff: Ent | undefined;
       for (const f of friends) {
@@ -583,7 +584,7 @@ export function act(ctx: Ctx, obs: Obs) {
 
     if (myTask.type === "CARRY") {
       const dHome = dist(me.x, me.y, MY.x, MY.y);
-      if (dHome <= TUNE.RELEASE_DIST) {
+      if (dHome < Math.min(TUNE.RELEASE_DIST, BASE_SCORE_RADIUS)) {
         candidates.push({ act: { type: "RELEASE" }, base: 120, deltas: [], tag: "RELEASE", reason: "carry" });
       }
       const center = myTask.target;

--- a/packages/agents/hybrid-params.ts
+++ b/packages/agents/hybrid-params.ts
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------
 
 export type Tune = {
-  RELEASE_DIST: number;       // distance to base to RELEASE
+  RELEASE_DIST: number;       // release when dHome < min(RELEASE_DIST, BASE_SCORE_RADIUS)
   STUN_RANGE: number;         // max range to STUN
   RADAR1_TURN: number;        // first scheduled RADAR (buster localIdx 0)
   RADAR2_TURN: number;        // second scheduled RADAR (buster localIdx 1)

--- a/packages/sim-runner/src/exporters/compileWeightsToJS.ts
+++ b/packages/sim-runner/src/exporters/compileWeightsToJS.ts
@@ -6,6 +6,7 @@ export function compileWeightsToSingleFile(bestVec: number[], jsOutPath: string)
   const src = `/** Auto-generated hybrid CG bot (EVOL2) */
 export const meta = { name: "HybridEvol2", version: "ga" };
 const W = ${JSON.stringify(w)};
+const BASE_SCORE_RADIUS = 1600;
 function D(ax,ay,bx,by){return Math.hypot(ax-bx,ay-by)}
 function R(self, ghost){
   const dx=ghost.x-self.x, dy=ghost.y-self.y;
@@ -18,7 +19,7 @@ export function act(ctx, obs){
   const me=obs.self;
   if (me.carrying !== undefined){
     const d=D(me.x,me.y,ctx.myBase.x,ctx.myBase.y);
-    if (d <= W.releaseDist) return { type:"RELEASE" };
+    if (d < Math.min(W.releaseDist, BASE_SCORE_RADIUS)) return { type:"RELEASE" };
     return { type:"MOVE", x: ctx.myBase.x, y: ctx.myBase.y };
   }
   const e0 = (obs.enemies&&obs.enemies.find(e=> e.carrying !== undefined)) || (obs.enemies && obs.enemies[0]);

--- a/packages/sim-runner/src/ga.ts
+++ b/packages/sim-runner/src/ga.ts
@@ -98,6 +98,7 @@ function vecStd(vs: number[][], m: number[]) {
 
 // ===== HOF =====
 const HOF: Genome[] = [];
+const BASE_SCORE_RADIUS = 1600; // must be strictly inside to score
 
 // ===== Bot from genome =====
 function genomeToBot(genome: Genome) {
@@ -106,7 +107,7 @@ function genomeToBot(genome: Genome) {
     act(ctx: any, obs: any) {
       if (obs.self.carrying !== undefined) {
         const dHome = Math.hypot(obs.self.x - ctx.myBase.x, obs.self.y - ctx.myBase.y);
-        if (dHome <= genome.releaseDist) return { type: 'RELEASE' };
+        if (dHome < Math.min(genome.releaseDist, BASE_SCORE_RADIUS)) return { type: 'RELEASE' };
         return { type: 'MOVE', x: ctx.myBase.x, y: ctx.myBase.y };
       }
       const enemy = obs.enemies?.[0];
@@ -581,7 +582,7 @@ export function compileGenomeToJS(inPath: string, outPath: string) {
     "export function act(ctx, obs) {",
     "  if (obs.self.carrying !== undefined) {",
     "    const d = Math.hypot(obs.self.x - ctx.myBase.x, obs.self.y - ctx.myBase.y);",
-    `    if (d <= ${g.releaseDist}) return { type: "RELEASE" };`,
+    `    if (d < Math.min(${g.releaseDist}, 1600)) return { type: "RELEASE" };`,
     "    return { type: \"MOVE\", x: ctx.myBase.x, y: ctx.myBase.y };",
     "  }",
     `  const enemy = obs.enemies?.[0];`,

--- a/packages/sim-runner/src/workerEvalRelease.test.ts
+++ b/packages/sim-runner/src/workerEvalRelease.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { genomeToBot } from './workerEval';
+
+test('carrier at base radius keeps moving toward base', () => {
+  const bot = genomeToBot({ radarTurn: 0, stunRange: 0, releaseDist: 1700 });
+  const ctx = { myBase: { x: 0, y: 0 } } as any;
+  const obs = { self: { x: 1600, y: 0, carrying: 0, stunCd: 0 }, enemies: [], ghostsVisible: [], tick: 0 } as any;
+  const action = bot.act(ctx, obs);
+  assert.equal(action.type, 'MOVE');
+});

--- a/scripts/export-cg-bot.mjs
+++ b/scripts/export-cg-bot.mjs
@@ -18,6 +18,7 @@ function dist(ax, ay, bx, by){ const dx=ax-bx, dy=ay-by; return Math.hypot(dx,dy
 
 const GENOME = { radarTurn:${g.radarTurn}, stunRange:${g.stunRange}, releaseDist:${g.releaseDist} };
 const BUST_MIN = 900, BUST_MAX = 1760;
+const BASE_SCORE_RADIUS = 1600;
 
 const bustersPerPlayer = parseInt(readline(),10);
 const ghostCount = parseInt(readline(),10);
@@ -74,7 +75,7 @@ while (true) {
 
     if (carrying){
       const dHome = dist(me.x, me.y, myBase.x, myBase.y);
-      if (dHome <= GENOME.releaseDist) { actions.push("RELEASE"); }
+      if (dHome < Math.min(GENOME.releaseDist, BASE_SCORE_RADIUS)) { actions.push("RELEASE"); }
       else { actions.push(\`MOVE \${myBase.x} \${myBase.y}\`); }
     } else {
       if (nearestEnemy && nearestEnemy.range <= GENOME.stunRange && myStun <= 0){

--- a/scripts/export-cg-bot.ts
+++ b/scripts/export-cg-bot.ts
@@ -43,6 +43,7 @@ function dist(ax, ay, bx, by){ const dx=ax-bx, dy=ay-by; return Math.hypot(dx,dy
 
 const GENOME = { radarTurn:${g.radarTurn}, stunRange:${g.stunRange}, releaseDist:${g.releaseDist} };
 const BUST_MIN = 900, BUST_MAX = 1760;
+const BASE_SCORE_RADIUS = 1600;
 const STUN_RANGE = GENOME.stunRange;
 
 // === Codingame init ===
@@ -124,10 +125,10 @@ while (true) {
     let gNear=null, gD=1e9;
     for (const gg of ghosts){ const d=dist(me.x,me.y,gg.x,gg.y); if(d<gD){gD=d; gNear=gg;} }
 
-    // 1) Carrying → go home, RELEASE when close
+    // 1) Carrying → go home, RELEASE when strictly inside base
     if (carrying){
       const dHome = dist(me.x, me.y, myBase.x, myBase.y);
-      actions[slot] = (dHome <= GENOME.releaseDist) ? "RELEASE" : \`MOVE \${myBase.x} \${myBase.y}\`;
+      actions[slot] = (dHome < Math.min(GENOME.releaseDist, BASE_SCORE_RADIUS)) ? "RELEASE" : \`MOVE \${myBase.x} \${myBase.y}\`;
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Require ghosts be released strictly inside the base by using `< Math.min(releaseDist, BASE_SCORE_RADIUS)`
- Guard worker evaluator so it can be imported in tests and expose `genomeToBot`
- Add unit test verifying carriers at the base radius keep moving toward home

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a871e6a3b4832b8e3e692d6cad487b