### PR TITLE
Include disruptor bots in training pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pnpm -C packages/sim-runner start train \
   --algo cem --pop 8 --gens 2 \
   --seeds-per 2 --eps-per-seed 1 \
   --jobs 1 --seed 42 \
-  --opp-pool greedy,random \
+    --opp-pool greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner \
   --hof 3
 # optional:
 #   --hof-refresh 5      # refresh HOF every 5 generations
@@ -58,7 +58,7 @@ pnpm -C packages/sim-runner start train \
   --algo cem --pop 24 --gens 8 \
   --seeds-per 5 --eps-per-seed 2 \
   --jobs 8 --seed 42 \
-  --opp-pool greedy,random \
+    --opp-pool greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner \
   --hof 5
 # optional flags as above
 ```

--- a/docs/EVOL2.md
+++ b/docs/EVOL2.md
@@ -237,7 +237,7 @@ The `sim-runner` package drives evolutionary training and evaluation.
 pnpm -C packages/sim-runner start train \
   --algo cem --pop 24 --gens 12 \
   --seeds-per 7 --seed 42 \
-  --opp-pool greedy,random,hof --hof 6
+  --opp-pool greedy,random,stunner,camper,defender,scout,base-camper,aggressive-stunner,hof --hof 6
 # optional flags:
 #   --hof-refresh 5      refresh HOF every 5 generations
 #   --elo-out custom/path/elo.json  write Elo ratings here after each gen
@@ -252,14 +252,14 @@ Outputs are written to `packages/sim-runner/artifacts/`:
 pnpm -C packages/sim-runner start train \
   --algo cma --pop 32 --gens 20 \
   --seeds-per 7 --eps-per-seed 2 \
-  --opp-pool greedy,random,camper,stunner,defender,scout,hof --hof 8 --seed 42
+  --opp-pool greedy,random,camper,stunner,defender,scout,base-camper,aggressive-stunner,hof --hof 8 --seed 42
 ```
 
 ### Sample CMA-ES Run
 ```
 pnpm -C packages/sim-runner start train --subject hybrid --algo cma \
   --pop 4 --gens 2 --seeds-per 1 --eps-per-seed 1 \
-  --opp-pool greedy,random,camper,stunner,defender,scout --seed 42
+  --opp-pool greedy,random,camper,stunner,defender,scout,base-camper,aggressive-stunner --seed 42
 ```
 This quick run yielded a best fitness of 37.25 (≈37.5% win rate) and produced the
 parameters committed in `packages/agents/hybrid-params.ts`.

--- a/packages/sim-runner/src/algos/cem-weights.test.ts
+++ b/packages/sim-runner/src/algos/cem-weights.test.ts
@@ -33,7 +33,7 @@ test('trainCemWeights moves mean toward target', async () => {
     pop: 32,
     elitePct: 0.25,
     seed: 123,
-    oppPool: ['greedy', 'random'],
+    oppPool: ['greedy', 'random', 'base-camper', 'aggressive-stunner'],
     evaluate: evalFn,
     artifactsDir: tmpDir,
   });

--- a/packages/sim-runner/src/evalers/hybrid.ts
+++ b/packages/sim-runner/src/evalers/hybrid.ts
@@ -22,7 +22,7 @@ export const HYBRID_CLIP  = {
 
 // Minimal type to match your train code
 export type EvalOpts = {
-  oppPool: string[];      // e.g. ["greedy","stunner","camper","random","hybrid"]
+  oppPool: string[];      // e.g. ["greedy","stunner","camper","random","base-camper","aggressive-stunner","hybrid"]
   seeds: number[];
   epsPerSeed: number;
 };


### PR DESCRIPTION
## Summary
- Expand training EvalOpts comment to demonstrate new disruptor bots
- Cover base-camper and aggressive-stunner in CEM weights tests
- Document base-camper and aggressive-stunner in training examples

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87257de74832ba52f28a0ab17e07f