### PR TITLE
refactor: centralize radii constants in hybrid bot

### DIFF
--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -2,6 +2,7 @@ import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { contestedBustDelta, duelStunDelta, releaseBlockDelta, twoTurnContestDelta, ejectDelta, interceptDelta, twoTurnInterceptDelta, twoTurnEjectDelta, resetMicroPerf, microPerf, microOverBudget, MICRO_BUDGET_MS } from './micro';
 import { RULES } from '../shared/src/constants.ts';
+import { STUN_CHECK_RADIUS } from './hybrid-bot';
 
 // Verify contested bust uses projected positions
 const STUN = RULES.STUN_RANGE;
@@ -40,7 +41,7 @@ test('contested bust projects one turn ahead', () => {
 
 test('duel stun projects closing distance', () => {
   const me = { id: 1, x: 0, y: 0 };
-  const enemy = { id: 2, x: 2500, y: 0 };
+  const enemy = { id: 2, x: STUN_CHECK_RADIUS, y: 0 };
   const delta = duelStunDelta({
     me,
     enemy,

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -35,6 +35,7 @@ const twoTurnInterceptCache = new Map<string, number>();
 const twoTurnEjectCache = new Map<string, number>();
 
 const SPEED = RULES.MOVE_SPEED; // buster speed per turn
+const ENEMY_NEAR_RADIUS = RULES.VISION;
 
 type Pt = { x: number; y: number };
 type Ent = { id: number; x: number; y: number; state?: number; range?: number };
@@ -97,7 +98,7 @@ export function contestedBustDelta(opts: {
   const me1 = step(me, ghost);
   const enemies1 = enemies.map(e => step(e, ghost));
   const r = dist(me1.x, me1.y, ghost.x, ghost.y);
-  const near = enemies1.filter(e => dist(e.x, e.y, ghost.x, ghost.y) <= 2200);
+  const near = enemies1.filter(e => dist(e.x, e.y, ghost.x, ghost.y) <= ENEMY_NEAR_RADIUS);
   if (near.length === 0) return (r >= bustMin && r <= bustMax) ? +0.25 : 0;
 
   let delta = 0;


### PR DESCRIPTION
## Summary
- define ENEMY_NEAR_RADIUS, EJECT_RADIUS, and STUN_CHECK_RADIUS in hybrid bot
- replace magic numbers with the new constants and update helpers/tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8795cc740832b99f47a83d99225d7