### PR TITLE
Remove waypoint field from buster memory

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -7,7 +7,7 @@ import { hungarian } from './hungarian';
 
 test('mem resets on new match and repopulates', () => {
   // pre-populate with stale entry
-  __mem.set(99, { stunReadyAt: 5, radarUsed: true, wp: 1 });
+  __mem.set(99, { stunReadyAt: 5, radarUsed: true });
 
   const ctx: any = {};
   const baseObs: any = { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -67,9 +67,9 @@ type Obs = {
 };
 
 /** Memory per buster */
-const mem = new Map<number, { stunReadyAt: number; radarUsed: boolean; wp: number }>();
+const mem = new Map<number, { stunReadyAt: number; radarUsed: boolean }>();
 export const __mem = mem; // exposed for tests
-function M(id: number) { if (!mem.has(id)) mem.set(id, { stunReadyAt: 0, radarUsed: false, wp: 0 }); return mem.get(id)!; }
+function M(id: number) { if (!mem.has(id)) mem.set(id, { stunReadyAt: 0, radarUsed: false }); return mem.get(id)!; }
 let lastTick = Infinity;
 
 /** Patrol paths used as exploration frontiers (simple & fast) */


### PR DESCRIPTION
## Summary
- drop obsolete `wp` field from buster memory and init
- update tests to use patrol memory
- restore missing `codingame_bot.js`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8796106a4832b91c1e5bf0603aecd