### PR TITLE
test(sim-runner): verify hybrid ORDER covers param keys

### DIFF
--- a/packages/sim-runner/src/hybrid-order.test.ts
+++ b/packages/sim-runner/src/hybrid-order.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ORDER } from './subjects/hybrid';
+import { TUNE, WEIGHTS } from '@busters/agents/hybrid-params';
+
+test('ORDER covers all TUNE and WEIGHTS keys', () => {
+  const expected = [
+    ...Object.keys(TUNE).map(k => `TUNE.${k}`),
+    ...Object.keys(WEIGHTS).map(k => `WEIGHTS.${k}`),
+  ].sort();
+  const actual = [...ORDER].sort();
+  assert.deepEqual(actual, expected);
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring the hybrid ORDER vector includes all keys from TUNE and WEIGHTS

## Testing
- `pnpm --filter @busters/sim-runner test`


------
https://chatgpt.com/codex/tasks/task_e_68a879848bb8832bb4f29f85b45b3378