### PR TITLE
Use lightweight keys for micro rollout caches

### DIFF
--- a/packages/agents/micro.test.ts
+++ b/packages/agents/micro.test.ts
@@ -166,8 +166,7 @@ test('micro rollouts cache and stay under budget', () => {
   const enemy = { id: 2, x: 3000, y: 0 };
   const ghost = { x: 1000, y: 0 };
   const myBase = { x: 0, y: 0 };
-
-  const cOpts = {
+  const baseContest = {
     me,
     enemy,
     ghost,
@@ -176,37 +175,58 @@ test('micro rollouts cache and stay under budget', () => {
     stunRange: STUN,
     canStunMe: true,
     canStunEnemy: true,
-  };
-  const firstC = twoTurnContestDelta(cOpts);
+  } as const;
+  const firstC = twoTurnContestDelta({ ...baseContest, me: { ...me }, enemy: { ...enemy }, ghost: { ...ghost } });
+  const contestMs = microPerf.twoTurnMs;
   for (let i = 0; i < 5; i++) {
-    assert.equal(twoTurnContestDelta(cOpts), firstC);
+    const opts = { ...baseContest, me: { ...me }, enemy: { ...enemy }, ghost: { ...ghost } };
+    assert.equal(twoTurnContestDelta(opts), firstC);
   }
+  assert.equal(microPerf.twoTurnMs, contestMs);
 
-  const iOpts = {
+  const baseIntercept = {
     me,
     enemy,
     myBase,
     stunRange: STUN,
     canStunMe: true,
     canStunEnemy: true,
-  };
-  const firstI = twoTurnInterceptDelta(iOpts);
+  } as const;
+  const firstI = twoTurnInterceptDelta({ ...baseIntercept, me: { ...me }, enemy: { ...enemy }, myBase: { ...myBase } });
+  const interceptMs = microPerf.interceptMs;
   for (let i = 0; i < 5; i++) {
-    assert.equal(twoTurnInterceptDelta(iOpts), firstI);
+    const opts = { ...baseIntercept, me: { ...me }, enemy: { ...enemy }, myBase: { ...myBase } };
+    assert.equal(twoTurnInterceptDelta(opts), firstI);
   }
+  assert.equal(microPerf.interceptMs, interceptMs);
 
-  const eOpts = {
+  const baseEject = {
     me,
     enemy,
     target: { x: 800, y: 0 },
     myBase,
     stunRange: STUN,
     canStunEnemy: true,
-  };
-  const firstE = twoTurnEjectDelta(eOpts);
+  } as const;
+  const firstE = twoTurnEjectDelta({
+    ...baseEject,
+    me: { ...me },
+    enemy: { ...enemy },
+    target: { x: 800, y: 0 },
+    myBase: { ...myBase },
+  });
+  const ejectMs = microPerf.ejectMs;
   for (let i = 0; i < 5; i++) {
-    assert.equal(twoTurnEjectDelta(eOpts), firstE);
+    const opts = {
+      ...baseEject,
+      me: { ...me },
+      enemy: { ...enemy },
+      target: { x: 800, y: 0 },
+      myBase: { ...myBase },
+    };
+    assert.equal(twoTurnEjectDelta(opts), firstE);
   }
+  assert.equal(microPerf.ejectMs, ejectMs);
 
   assert.ok(!microOverBudget());
 });

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -34,6 +34,10 @@ const twoTurnContestCache = new Map<string, number>();
 const twoTurnInterceptCache = new Map<string, number>();
 const twoTurnEjectCache = new Map<string, number>();
 
+function cacheKey(...nums: number[]): string {
+  return nums.join('|');
+}
+
 const SPEED = RULES.MOVE_SPEED; // buster speed per turn
 const ENEMY_NEAR_RADIUS = RULES.VISION;
 
@@ -126,11 +130,24 @@ export function twoTurnContestDelta(opts: {
 }) {
   microPerf.twoTurnCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
+  const key = cacheKey(
+    me.x,
+    me.y,
+    enemy.x,
+    enemy.y,
+    ghost ? 1 : 0,
+    ghost?.x ?? 0,
+    ghost?.y ?? 0,
+    bustMin,
+    bustMax,
+    stunRange,
+    canStunMe ? 1 : 0,
+    canStunEnemy ? 1 : 0,
+  );
   const cached = twoTurnContestCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
   const me1 = step(me, ghost ?? enemy);
   const enemy1 = step(enemy, ghost ?? me);
   let delta = duelStunDelta({
@@ -177,11 +194,21 @@ export function twoTurnInterceptDelta(opts: {
 }) {
   microPerf.interceptCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, myBase, stunRange, canStunMe, canStunEnemy } = opts;
+  const key = cacheKey(
+    me.x,
+    me.y,
+    enemy.x,
+    enemy.y,
+    myBase.x,
+    myBase.y,
+    stunRange,
+    canStunMe ? 1 : 0,
+    canStunEnemy ? 1 : 0,
+  );
   const cached = twoTurnInterceptCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, myBase, stunRange, canStunMe, canStunEnemy } = opts;
   const P = estimateInterceptPoint(me, enemy, myBase);
   const me1 = step(me, P);
   const enemy1 = step(enemy, myBase);
@@ -256,11 +283,22 @@ export function twoTurnEjectDelta(opts: {
 }) {
   microPerf.ejectCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, target, myBase, stunRange, canStunEnemy } = opts;
+  const key = cacheKey(
+    me.x,
+    me.y,
+    enemy.x,
+    enemy.y,
+    target.x,
+    target.y,
+    myBase.x,
+    myBase.y,
+    stunRange,
+    canStunEnemy ? 1 : 0,
+  );
   const cached = twoTurnEjectCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, target, myBase, stunRange, canStunEnemy } = opts;
   const me1 = step(me, target);
   const enemy1 = step(enemy, target);
   let delta = ejectDelta({ me: me1, target, myBase });


### PR DESCRIPTION
## Summary
- Replace JSON.stringify with lightweight string keys for micro rollout caches
- Ensure contest, intercept, and eject rollouts share new key format
- Expand tests to verify caching via stable micro performance counters

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a880760704832bad6283191aa8034d