### PR TITLE
feat: make hungarian auction threshold configurable

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -128,6 +128,25 @@ test('runAuction uses greedy assignment when combinations exceed 100', () => {
   assert.ok(!assigned.has(team[10].id));
 });
 
+test('runAuction respects HUNGARIAN_MAX_COMBOS override', async () => {
+  process.env.HUNGARIAN_MAX_COMBOS = '50';
+  const mod = await import('./hybrid-bot.ts?override');
+  const { __runAuction, HUNGARIAN_MAX_COMBOS } = mod;
+  const { HybridState } = await import('./lib/state.ts');
+  assert.equal(HUNGARIAN_MAX_COMBOS, 50);
+  const team = Array.from({ length: 8 }, (_, i) => ({ id: i + 1, x: i * 100, y: 0 }));
+  const tasks = Array.from({ length: 7 }, (_, i) => ({ type: 'EXPLORE', target: { x: i * 100, y: 0 }, baseScore: 100 }));
+  const enemies: any[] = [];
+  const MY = { x: 0, y: 0 };
+  const tick = 0;
+  const st = new HybridState();
+  st.updateRoles(team as any);
+  const assigned = __runAuction(team as any, tasks as any, enemies, MY, tick, st);
+  assert.equal(assigned.size, tasks.length);
+  assert.ok(!assigned.has(team[7].id));
+  delete process.env.HUNGARIAN_MAX_COMBOS;
+});
+
 test('bot does not stun an already stunned enemy', () => {
   __mem.clear();
   const ctx: any = {};

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -372,11 +372,14 @@ function scoreAssign(b: Ent, t: Task, enemies: Ent[], MY: Pt, tick: number, stat
 }
 
 /** Auction/assignment: use Hungarian for optimal matching when manageable */
+export const HUNGARIAN_MAX_COMBOS = Number(
+  (typeof process !== "undefined" ? process.env.HUNGARIAN_MAX_COMBOS : undefined) ?? 100
+);
 function runAuction(team: Ent[], tasks: Task[], enemies: Ent[], MY: Pt, tick: number, state: HybridState): Map<number, Task> {
   const assigned = new Map<number, Task>();
 
   // Use Hungarian when both team and task sizes are reasonable
-  if (team.length && tasks.length && team.length * tasks.length <= 100) {
+  if (team.length && tasks.length && team.length * tasks.length <= HUNGARIAN_MAX_COMBOS) {
     const cost = team.map(b =>
       tasks.map(t => -scoreAssign(b, t, enemies, MY, tick, state))
     );


### PR DESCRIPTION
## Summary
- allow configuring the Hungarian assignment limit via `HUNGARIAN_MAX_COMBOS`
- document and test env override for auction threshold

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a880805418832b8e34d4a4f1eabc27