### PR TITLE
refactor: inject HybridState for hybrid bot

### DIFF
--- a/packages/agents/bench-act.ts
+++ b/packages/agents/bench-act.ts
@@ -1,4 +1,5 @@
 import { act, __mem, __pMem } from './hybrid-bot';
+import { HybridState } from './lib/state';
 import { resetMicroPerf } from './micro';
 import { performance } from 'node:perf_hooks';
 
@@ -45,6 +46,7 @@ const runs = 90;
 const times: number[] = [];
 __mem.clear();
 __pMem.clear();
+const state = new HybridState();
 for (let i = 0; i < runs; i++) {
   const base = scenarios[i % scenarios.length];
   const ctx = { ...base.ctx, tick: i } as any;
@@ -58,7 +60,7 @@ for (let i = 0; i < runs; i++) {
   } as any;
   resetMicroPerf();
   const start = performance.now();
-  act(ctx, obs);
+  act(ctx, obs, state);
   times.push(performance.now() - start);
 }
 

--- a/packages/agents/cg-adapter.ts
+++ b/packages/agents/cg-adapter.ts
@@ -11,6 +11,7 @@ declare function readline(): string;
 declare function print(s: string): void;
 
 import { act } from "./hybrid-bot";
+import { HybridState } from "./lib/state";
 
 type Pt = { x: number; y: number };
 
@@ -27,6 +28,7 @@ const myTeamId = parseInt(readline(), 10);
 const myBase: Pt = myTeamId === 0 ? { x: 0, y: 0 } : { x: W, y: H };
 const enemyBase: Pt = myTeamId === 0 ? { x: W, y: H } : { x: 0, y: 0 };
 const ctx = { myBase, enemyBase, bounds: { w: W, h: H } };
+const state = new HybridState({ w: W, h: H });
 
 function d(a: Pt, b: Pt) { return Math.hypot(a.x - b.x, a.y - b.y); }
 
@@ -74,7 +76,7 @@ while (true) {
 
     const obs = { self, enemies, ghostsVisible, tick };
 
-    const a = act(ctx, obs) || { type: "MOVE", x: myBase.x, y: myBase.y };
+    const a = act(ctx, obs, state) || { type: "MOVE", x: myBase.x, y: myBase.y };
     switch (a.type) {
       case "MOVE": {
         const x = Math.max(0, Math.min(W, Math.round(a.x)));

--- a/packages/agents/hof.ts
+++ b/packages/agents/hof.ts
@@ -7,8 +7,9 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import * as Hybrid from "./hybrid-bot";
+import { HybridState } from "./lib/state";
 
-type Bot = { meta: any; act: (ctx: any, obs: any) => any };
+type Bot = { meta: any; act: (ctx: any, obs: any, state?: HybridState) => any };
 
 function normalize(mod: any): Bot {
   const m = mod?.default ?? mod;
@@ -37,6 +38,7 @@ try {
 
 if (!cand.length) cand.push(normalize(Hybrid));
 let chosen: Bot = cand[Math.floor(Math.random() * cand.length)];
+let state: HybridState | undefined;
 
 export const candidates = cand;
 export function random() {
@@ -45,7 +47,8 @@ export function random() {
 
 export const meta = { name: `HOF(${chosen.meta?.name ?? "?"})`, ...chosen.meta };
 export function act(ctx: any, obs: any) {
-  return chosen.act(ctx, obs);
+  state ??= new HybridState(ctx?.bounds);
+  return chosen.act(ctx, obs, state);
 }
 export default { meta, act };
 

--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -11,12 +11,13 @@ test('mem resets on new match and repopulates', () => {
 
   const ctx: any = {};
   const baseObs: any = { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
-  act(ctx, baseObs);
+  const st = new HybridState();
+  act(ctx, baseObs, st);
   assert.ok(!__mem.has(99));
   assert.ok(__mem.has(1));
 
   const nextObs: any = { tick: 2, self: { id: 2, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
-  act(ctx, nextObs);
+  act(ctx, nextObs, st);
   assert.ok(__mem.has(1) && __mem.has(2));
 });
 
@@ -27,7 +28,8 @@ test('patrol indices reset on new match', () => {
 
   const ctx: any = {};
   const obs: any = { tick: 0, self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] };
-  act(ctx, obs);
+  const st = new HybridState();
+  act(ctx, obs, st);
 
   // old entries cleared and waypoint reset to zero
   assert.equal(__pMem.get(1)?.wp, 0);
@@ -132,16 +134,17 @@ test('bot does not stun an already stunned enemy', () => {
   __mem.clear();
   const ctx: any = {};
   const self = { id: 1, x: 0, y: 0, state: 0 };
+  const st = new HybridState();
   let obs: any = { tick: 0, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
-  let action = act(ctx, obs);
+  let action = act(ctx, obs, st);
   assert.equal(action.type, 'STUN');
 
   obs = { tick: 21, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 2, range: 0, stunnedFor: 5 }], ghostsVisible: [] };
-  action = act(ctx, obs);
+  action = act(ctx, obs, st);
   assert.notEqual(action.type, 'STUN');
 
   obs = { tick: 22, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
-  action = act(ctx, obs);
+  action = act(ctx, obs, st);
   assert.equal(action.type, 'STUN');
 });
 
@@ -165,7 +168,8 @@ test('ejects when threatened and stun on cooldown', () => {
   const self = { id: 1, x: 4000, y: 4000, state: 1, stunCd: 5 };
   const enemy = { id: 2, x: 4200, y: 4000, state: 0, range: 200, stunnedFor: 0 };
   const obs: any = { tick: 10, self, friends: [], enemies: [enemy], ghostsVisible: [] };
-  const actRes = act(ctx, obs);
+  const st = new HybridState();
+  const actRes = act(ctx, obs, st);
   assert.equal(actRes.type, 'EJECT');
 });
 
@@ -175,7 +179,8 @@ test('ejects to closer ally when safe', () => {
   const self = { id: 1, x: 6000, y: 6000, state: 1, stunCd: 10 };
   const ally = { id: 3, x: 5000, y: 5000, state: 0 };
   const obs: any = { tick: 5, self, friends: [ally], enemies: [], ghostsVisible: [] };
-  const actRes = act(ctx, obs);
+  const st = new HybridState();
+  const actRes = act(ctx, obs, st);
   assert.equal(actRes.type, 'EJECT');
 });
 
@@ -185,7 +190,8 @@ test('does not eject when stun ready', () => {
   const self = { id: 1, x: 4000, y: 4000, state: 1, stunCd: 0 };
   const enemy = { id: 2, x: 4200, y: 4000, state: 0, range: 200, stunnedFor: 0 };
   const obs: any = { tick: 10, self, friends: [], enemies: [enemy], ghostsVisible: [] };
-  const actRes = act(ctx, obs);
+  const st = new HybridState();
+  const actRes = act(ctx, obs, st);
   assert.notEqual(actRes.type, 'EJECT');
 });
 

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -4,7 +4,7 @@ export const meta = { name: "HybridBaseline" };
 // Params are imported so CEM can overwrite them.
 import HYBRID_PARAMS, { TUNE as TUNE_IN, WEIGHTS as WEIGHTS_IN } from "./hybrid-params";
 import { Fog } from "./fog";
-import { HybridState, getState, predictEnemyPath } from "./lib/state";
+import { HybridState, predictEnemyPath } from "./lib/state";
 import {
   estimateInterceptPoint,
   duelStunDelta,
@@ -418,7 +418,7 @@ export const __buildTasks = buildTasks;
 export const __fog = fog;
 
 /** --- Main per-buster policy --- */
-export function act(ctx: Ctx, obs: Obs) {
+export function act(ctx: Ctx, obs: Obs, state: HybridState) {
   resetMicroPerf();
   const tick = (ctx.tick ?? obs.tick ?? 0) | 0;
   if (tick <= 1 && tick < lastTick) {
@@ -437,7 +437,6 @@ export function act(ctx: Ctx, obs: Obs) {
     return act;
   };
   const m = M(me.id);
-  const state = getState(ctx, obs);
   state.trackEnemies(obs.enemies, tick);
   state.decayGhosts();
   state.diffuseGhosts();

--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -304,11 +304,22 @@ export function predictEnemyPath(e: EnemySeen, base: Pt, ticks: number): Pt[] {
 // ---- singleton per process (fine while only our team uses this bot) ----
 type AnyObj = Record<string, any>;
 const G: AnyObj = (globalThis as AnyObj).__HYBRID_STATE__ ||= {};
-export function getState(ctx: any, obs: any): HybridState {
+
+/**
+ * Retrieve or create a HybridState scoped by a unique key.
+ * Callers should store the returned instance and pass it to `act` on
+ * subsequent ticks so we don't rely on a global singleton.
+ */
+export function getState(key: string, ctx: any, obs: any): HybridState {
   // Reset on new match or at tick 0/1 to be safe
-  const key = "team"; // one state is fine for our side in this runner
   if (!G[key] || obs?.tick <= 1) {
-    G[key] = new HybridState(ctx?.bounds, 8, 5, DEFAULT_ENEMY_MAX_AGE, ctx?.ghostSpawns);
+    G[key] = new HybridState(
+      ctx?.bounds,
+      8,
+      5,
+      DEFAULT_ENEMY_MAX_AGE,
+      ctx?.ghostSpawns,
+    );
   }
   return G[key] as HybridState;
 }


### PR DESCRIPTION
## Summary
- refactor shared getState to accept a caller-provided key
- require HybridState to be created by callers and passed into hybrid-bot
- update adapters, HOF wrapper, bench, and tests to supply state

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a88095585c832b84a281fa375fc30c