### PR TITLE
perf: reduce micro cache key allocations

### DIFF
--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -126,11 +126,17 @@ export function twoTurnContestDelta(opts: {
 }) {
   microPerf.twoTurnCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
+  // Manual key concatenation to avoid JSON.stringify allocations
+  const key =
+    me.id + '|' + me.x + '|' + me.y + '|' +
+    enemy.id + '|' + enemy.x + '|' + enemy.y + '|' +
+    (ghost ? (ghost.id ?? 0) + '|' + ghost.x + '|' + ghost.y : '0|0|0') + '|' +
+    bustMin + '|' + bustMax + '|' + stunRange + '|' +
+    (canStunMe ? 1 : 0) + '|' + (canStunEnemy ? 1 : 0);
   const cached = twoTurnContestCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
   const me1 = step(me, ghost ?? enemy);
   const enemy1 = step(enemy, ghost ?? me);
   let delta = duelStunDelta({
@@ -177,11 +183,15 @@ export function twoTurnInterceptDelta(opts: {
 }) {
   microPerf.interceptCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, myBase, stunRange, canStunMe, canStunEnemy } = opts;
+  const key =
+    me.id + '|' + me.x + '|' + me.y + '|' +
+    enemy.id + '|' + enemy.x + '|' + enemy.y + '|' +
+    myBase.x + '|' + myBase.y + '|' + stunRange + '|' +
+    (canStunMe ? 1 : 0) + '|' + (canStunEnemy ? 1 : 0);
   const cached = twoTurnInterceptCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, myBase, stunRange, canStunMe, canStunEnemy } = opts;
   const P = estimateInterceptPoint(me, enemy, myBase);
   const me1 = step(me, P);
   const enemy1 = step(enemy, myBase);
@@ -256,11 +266,16 @@ export function twoTurnEjectDelta(opts: {
 }) {
   microPerf.ejectCalls++;
   if (microOverBudget()) return 0;
-  const key = JSON.stringify(opts);
+  const { me, enemy, target, myBase, stunRange, canStunEnemy } = opts;
+  const key =
+    me.id + '|' + me.x + '|' + me.y + '|' +
+    enemy.id + '|' + enemy.x + '|' + enemy.y + '|' +
+    target.x + '|' + target.y + '|' +
+    myBase.x + '|' + myBase.y + '|' + stunRange + '|' +
+    (canStunEnemy ? 1 : 0);
   const cached = twoTurnEjectCache.get(key);
   if (cached !== undefined) return cached;
   const t0 = performance.now();
-  const { me, enemy, target, myBase, stunRange, canStunEnemy } = opts;
   const me1 = step(me, target);
   const enemy1 = step(enemy, target);
   let delta = ejectDelta({ me: me1, target, myBase });


### PR DESCRIPTION
## Summary
- avoid JSON.stringify when building cache keys in micro rollouts
- construct keys via number concatenation to cut allocations and GC churn

## Testing
- `pnpm test`
- `node --trace-gc --import=tsx micro_bench.ts` (baseline vs after: 18 ➝ 15 GC log lines)


------
https://chatgpt.com/codex/tasks/task_e_68a880be9e38832b9ce7b8b4530b2163