### PR TITLE
refactor hybrid bot state to per-match factory

### DIFF
--- a/packages/agents/bench-act.ts
+++ b/packages/agents/bench-act.ts
@@ -1,4 +1,5 @@
-import { act, __mem, __pMem } from './hybrid-bot';
+import { createBot } from './hybrid-bot';
+const { act, __mem, __pMem } = createBot();
 import { resetMicroPerf } from './micro';
 import { performance } from 'node:perf_hooks';
 

--- a/packages/agents/cg-adapter.ts
+++ b/packages/agents/cg-adapter.ts
@@ -10,7 +10,8 @@
 declare function readline(): string;
 declare function print(s: string): void;
 
-import { act } from "./hybrid-bot";
+import { createBot } from "./hybrid-bot";
+const { act } = createBot();
 
 type Pt = { x: number; y: number };
 


### PR DESCRIPTION
## Summary
- create `StateFactory` for per-match `HybridState`
- expose `createBot` to isolate bot memory for each match
- adapt scripts and tests to new factory API

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a880c2dc14832b935786a2d5846ef1