### PR TITLE
feat: enhance enemy path prediction

### DIFF
--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -292,11 +292,15 @@ export function predictEnemyPath(e: EnemySeen, base: Pt, ticks: number): Pt[] {
       const d = Math.hypot(dx, dy) || 1;
       v = { x: (dx / d) * RULES.MOVE_SPEED, y: (dy / d) * RULES.MOVE_SPEED };
     }
-    cur = { x: cur.x + v.x, y: cur.y + v.y };
+    cur = {
+      x: clamp(cur.x + v.x, 0, MAP_W),
+      y: clamp(cur.y + v.y, 0, MAP_H)
+    };
     path.push({ x: Math.round(cur.x), y: Math.round(cur.y) });
     const bx = base.x - cur.x, by = base.y - cur.y;
     if (Math.hypot(bx, by) <= RULES.MOVE_SPEED) break;
-    if (v.x * bx + v.y * by <= 0) v = undefined;
+    const d = Math.hypot(bx, by) || 1;
+    v = { x: (bx / d) * RULES.MOVE_SPEED, y: (by / d) * RULES.MOVE_SPEED };
   }
   return path;
 }

--- a/packages/agents/state.test.ts
+++ b/packages/agents/state.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { HybridState, predictEnemyPath } from './lib/state';
+import { HybridState, predictEnemyPath, type EnemySeen } from './lib/state';
 
 test('trackEnemies records velocity and last two positions', () => {
   const st = new HybridState();
@@ -19,7 +19,46 @@ test('predictEnemyPath extrapolates toward base', () => {
   const e = st.enemies.get(1)!;
   const path = predictEnemyPath(e, { x: 0, y: 0 }, 2);
   assert.deepEqual(path[0], { x: 1000, y: 1000 });
-  assert.deepEqual(path[1], { x: 200, y: 1000 });
+  assert.deepEqual(path[1], { x: 434, y: 434 });
+});
+
+test('predictEnemyPath reorients when velocity away from base', () => {
+  const e: EnemySeen = {
+    id: 1,
+    last: { x: 1000, y: 1000 },
+    vel: { x: 800, y: 0 },
+    lastTick: 0,
+    carrying: false,
+    stunCd: undefined,
+  };
+  const base = { x: 0, y: 0 };
+  const path = predictEnemyPath(e, base, 3);
+  assert.deepEqual(path[0], { x: 1800, y: 1000 });
+  assert.deepEqual(path[1], { x: 1101, y: 611 });
+});
+
+test('predictEnemyPath clamps to map bounds', () => {
+  const base = { x: 8000, y: 4500 };
+  const eLow: EnemySeen = {
+    id: 1,
+    last: { x: 100, y: 100 },
+    vel: { x: -800, y: -800 },
+    lastTick: 0,
+    carrying: false,
+    stunCd: undefined,
+  };
+  const eHigh: EnemySeen = {
+    id: 2,
+    last: { x: 15900, y: 8900 },
+    vel: { x: 800, y: 800 },
+    lastTick: 0,
+    carrying: false,
+    stunCd: undefined,
+  };
+  const low = predictEnemyPath(eLow, base, 2);
+  const high = predictEnemyPath(eHigh, base, 2);
+  assert.deepEqual(low[0], { x: 0, y: 0 });
+  assert.deepEqual(high[0], { x: 16000, y: 9000 });
 });
 
 test('updateCorridors tracks unseen carrier path and decays', () => {


### PR DESCRIPTION
## Summary
- update enemy path prediction to clamp movement to map bounds and retarget toward base each tick
- add comprehensive tests for velocity reorientation and boundary handling

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a880d0caa0832bb252e9b39c0fbc9b