### PR TITLE
Avoid re-stunning already stunned enemies

### DIFF
--- a/packages/agents/aggressive-stunner.js
+++ b/packages/agents/aggressive-stunner.js
@@ -19,7 +19,7 @@ export function act(ctx, obs) {
     .map(e => ({ e, d: Math.hypot(me.x - e.x, me.y - e.y) }))
     .sort((a, b) => a.d - b.d)[0];
   if (enemy) {
-    if (enemy.d <= 1760 && me.stunCd <= 0) {
+    if (enemy.d <= 1760 && me.stunCd <= 0 && (enemy.e.stunnedFor ?? 0) <= 0) {
       return { type: "STUN", busterId: enemy.e.id };
     }
     return { type: "MOVE", x: enemy.e.x, y: enemy.e.y };

--- a/packages/agents/aggro-chaser.js
+++ b/packages/agents/aggro-chaser.js
@@ -17,7 +17,7 @@ export function act(ctx, obs) {
   // Enemy priority
   const enemy = (obs.enemies||[]).map(e => ({e, d: Math.hypot(me.x-e.x, me.y-e.y)}))
     .sort((a,b)=>a.d-b.d)[0];
-  if (enemy && enemy.d <= 1760 && me.stunCd <= 0) {
+  if (enemy && enemy.d <= 1760 && me.stunCd <= 0 && (enemy.e.stunnedFor ?? 0) <= 0) {
     return { type:"STUN", busterId: enemy.e.id };
   }
 

--- a/packages/agents/base-camper.js
+++ b/packages/agents/base-camper.js
@@ -19,7 +19,7 @@ export function act(ctx, obs) {
   const enemy = (obs.enemies || [])
     .map(e => ({ e, d: Math.hypot(me.x - e.x, me.y - e.y) }))
     .sort((a, b) => a.d - b.d)[0];
-  if (enemy && enemy.d <= 1760 && me.stunCd <= 0) {
+  if (enemy && enemy.d <= 1760 && me.stunCd <= 0 && (enemy.e.stunnedFor ?? 0) <= 0) {
     return { type: "STUN", busterId: enemy.e.id };
   }
 

--- a/packages/agents/camper-stunner.js
+++ b/packages/agents/camper-stunner.js
@@ -18,7 +18,7 @@ export function act(ctx, obs) {
   // Opportunistic stun near enemy base
   const nearEnemy = (obs.enemies||[]).map(e => ({e, d: Math.hypot(me.x-e.x, me.y-e.y)}))
     .sort((a,b)=>a.d-b.d)[0];
-  if (nearEnemy && nearEnemy.d <= 1760 && me.stunCd <= 0) {
+  if (nearEnemy && nearEnemy.d <= 1760 && me.stunCd <= 0 && (nearEnemy.e.stunnedFor ?? 0) <= 0) {
     return { type:"STUN", busterId: nearEnemy.e.id };
   }
 

--- a/packages/agents/defender-bot.ts
+++ b/packages/agents/defender-bot.ts
@@ -16,7 +16,7 @@ export function act(ctx: AgentContext, obs: Observation): Action {
     .map(e => ({ e, dMe: Math.hypot(me.x - e.x, me.y - e.y), dBase: Math.hypot(ctx.myBase.x - e.x, ctx.myBase.y - e.y) }))
     .filter(e => e.dBase <= 4000)
     .sort((a, b) => a.dMe - b.dMe)[0];
-  if (enemies && enemies.dMe <= 1760 && me.stunCd <= 0) {
+  if (enemies && enemies.dMe <= 1760 && me.stunCd <= 0 && (enemies.e.stunnedFor ?? 0) <= 0) {
     return { type: 'STUN', busterId: enemies.e.id };
   }
 

--- a/packages/agents/evolved-bot.js
+++ b/packages/agents/evolved-bot.js
@@ -7,7 +7,7 @@ export function act(ctx, obs) {
     return { type: "MOVE", x: ctx.myBase.x, y: ctx.myBase.y };
   }
   const enemy = obs.enemies?.[0];
-  if (enemy && enemy.range <= 1589 && obs.self.stunCd <= 0) return { type: "STUN", busterId: enemy.id };
+  if (enemy && enemy.range <= 1589 && obs.self.stunCd <= 0 && (enemy.stunnedFor ?? 0) <= 0) return { type: "STUN", busterId: enemy.id };
   const ghost = obs.ghostsVisible?.[0];
   if (ghost) {
     if (ghost.range >= 900 && ghost.range <= 1760) return { type: "BUST", ghostId: ghost.id };

--- a/packages/agents/evolved-hybrid-bot.js
+++ b/packages/agents/evolved-hybrid-bot.js
@@ -7,7 +7,7 @@ export function act(ctx, obs) {
     return { type: "MOVE", x: ctx.myBase.x, y: ctx.myBase.y };
   }
   const enemy = obs.enemies?.[0];
-  if (enemy && enemy.range <= 1647 && obs.self.stunCd <= 0) return { type: "STUN", busterId: enemy.id };
+  if (enemy && enemy.range <= 1647 && obs.self.stunCd <= 0 && (enemy.stunnedFor ?? 0) <= 0) return { type: "STUN", busterId: enemy.id };
   const ghost = obs.ghostsVisible?.[0];
   if (ghost) {
     if (ghost.range >= 900 && ghost.range <= 1760) return { type: "BUST", ghostId: ghost.id };

--- a/packages/agents/greedy-buster.js
+++ b/packages/agents/greedy-buster.js
@@ -7,7 +7,7 @@ export function act(ctx, obs) {
   }
   // Stun nearest enemy if in range and off cooldown
   const enemy = obs.enemies[0];
-  if (enemy && enemy.range <= 1700 && obs.self.stunCd <= 0) return { type: 'STUN', busterId: enemy.id };
+  if (enemy && enemy.range <= 1700 && obs.self.stunCd <= 0 && (enemy.stunnedFor ?? 0) <= 0) return { type: 'STUN', busterId: enemy.id };
   const g = obs.ghostsVisible[0];
   if (g) {
     if (g.range >= 900 && g.range <= 1760) return { type: 'BUST', ghostId: g.id };

--- a/packages/agents/scout-bot.ts
+++ b/packages/agents/scout-bot.ts
@@ -22,7 +22,7 @@ export function act(ctx: AgentContext, obs: Observation): Action {
   const enemy = (obs.enemies || [])
     .map(e => ({ e, d: Math.hypot(me.x - e.x, me.y - e.y) }))
     .sort((a, b) => a.d - b.d)[0];
-  if (enemy && enemy.d <= 1760 && me.stunCd <= 0) {
+  if (enemy && enemy.d <= 1760 && me.stunCd <= 0 && (enemy.e.stunnedFor ?? 0) <= 0) {
     return { type: 'STUN', busterId: enemy.e.id };
   }
 

--- a/packages/agents/stun-logic.test.ts
+++ b/packages/agents/stun-logic.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { act as aggressiveStunner } from './aggressive-stunner.js';
+import { act as aggroChaser } from './aggro-chaser.js';
+import { act as baseCamper } from './base-camper.js';
+import { act as camperStunner } from './camper-stunner.js';
+import { act as greedyBuster } from './greedy-buster.js';
+import { act as defenderBot } from './defender-bot.ts';
+import { act as scoutBot } from './scout-bot.ts';
+import { act as evolvedBot } from './evolved-bot.js';
+import { act as evolvedHybridBot } from './evolved-hybrid-bot.js';
+
+const ctx: any = { myBase: { x: 0, y: 0 }, myTeamId: 0, mapW: 16000, mapH: 9000 };
+
+const agents: [string, Function][] = [
+  ['aggressive-stunner', aggressiveStunner],
+  ['aggro-chaser', aggroChaser],
+  ['base-camper', baseCamper],
+  ['camper-stunner', camperStunner],
+  ['greedy-buster', greedyBuster],
+  ['defender-bot', defenderBot],
+  ['scout-bot', scoutBot],
+  ['evolved-bot', evolvedBot],
+  ['evolved-hybrid-bot', evolvedHybridBot],
+];
+
+for (const [name, agent] of agents) {
+  test(`${name} avoids re-stunning an already stunned enemy`, () => {
+    const obs: any = {
+      tick: 0,
+      self: { id: 0, x: 0, y: 0, stunCd: 0, carrying: undefined, radarUsed: true },
+      enemies: [{ id: 1, x: 0, y: 0, range: 0, stunnedFor: 5 }],
+      ghostsVisible: [],
+    };
+    const action = agent(ctx, obs);
+    assert.notEqual(action.type, 'STUN');
+  });
+
+  test(`${name} waits for stun cooldown before stunning again`, () => {
+    const obs: any = {
+      tick: 0,
+      self: { id: 0, x: 0, y: 0, stunCd: 10, carrying: undefined, radarUsed: true },
+      enemies: [{ id: 1, x: 0, y: 0, range: 0, stunnedFor: 0 }],
+      ghostsVisible: [],
+    };
+    const action = agent(ctx, obs);
+    assert.notEqual(action.type, 'STUN');
+  });
+}


### PR DESCRIPTION
## Summary
- Guard STUN logic across simple agents with enemy.stunnedFor checks
- Add regression tests to ensure bots skip STUN when target is already stunned or their own stun cooldown is active

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88556cff4832ba4d0baa744643b9f