### PR TITLE
Expose hybrid param helpers

### DIFF
--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -2,7 +2,7 @@
 export const meta = { name: "HybridBaseline" };
 
 // Params are imported so CEM can overwrite them.
-import HYBRID_PARAMS, { TUNE as TUNE_IN, WEIGHTS as WEIGHTS_IN } from "./hybrid-params";
+import HYBRID_PARAMS, { TUNE as TUNE_IN, WEIGHTS as WEIGHTS_IN, Tune, Weights } from "./hybrid-params";
 import { Fog } from "./fog";
 import { HybridState, getState, predictEnemyPath } from "./lib/state";
 import {
@@ -30,8 +30,13 @@ const micro = (fn: () => number) => (microOverBudget() ? 0 : fn());
 const fog = new Fog();
 
 /** Bind params locally (reads from hybrid-params) */
-const TUNE = TUNE_IN;
-const WEIGHTS = WEIGHTS_IN as any;
+const TUNE: Tune = TUNE_IN;
+const WEIGHTS: Weights = WEIGHTS_IN as any;
+
+export function setHybridParams(params: { TUNE: Partial<Tune>; WEIGHTS: Partial<Weights> }) {
+  Object.assign(TUNE, params.TUNE);
+  Object.assign(WEIGHTS, params.WEIGHTS);
+}
 
 /** --- Small utils (no imports) --- */
 const W = 16000, H = 9000;

--- a/packages/sim-runner/src/hybrid-eval.test.ts
+++ b/packages/sim-runner/src/hybrid-eval.test.ts
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateHybrid, HYBRID_MEAN } from './evalers/hybrid';
+
+test('evaluateHybrid executes with default vector', async () => {
+  const score = await evaluateHybrid(HYBRID_MEAN, { oppPool: [], seeds: [], epsPerSeed: 1 });
+  assert.equal(typeof score, 'number');
+});


### PR DESCRIPTION
## Summary
- expose hybrid parameter keys, bounds and vector conversion helpers
- add setter for hybrid params in agent
- smoke test hybrid evaluator builds

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a886cf275c832bb40488386dc6d2a2