### PR TITLE
feat(sim-runner): support new hybrid weights

### DIFF
--- a/packages/sim-runner/src/hybrid-order.test.ts
+++ b/packages/sim-runner/src/hybrid-order.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { ORDER } from './subjects/hybrid';
+import { ORDER, baselineVec, twFromVec, vecFromTW } from './subjects/hybrid';
 import { TUNE, WEIGHTS } from '@busters/agents/hybrid-params';
 
 test('ORDER covers all TUNE and WEIGHTS keys', () => {
@@ -10,4 +10,10 @@ test('ORDER covers all TUNE and WEIGHTS keys', () => {
   ].sort();
   const actual = [...ORDER].sort();
   assert.deepEqual(actual, expected);
+});
+
+test('baseline vector round-trips through twFromVec and vecFromTW', () => {
+  const base = baselineVec();
+  const round = vecFromTW(twFromVec(base));
+  assert.deepEqual(round, base);
 });

--- a/packages/sim-runner/src/subjects/hybrid.ts
+++ b/packages/sim-runner/src/subjects/hybrid.ts
@@ -88,7 +88,10 @@ export function twFromVec(vec: number[]): TW {
     DEFEND_NEAR_BONUS: Math.round(clamp(pick("WEIGHTS.DEFEND_NEAR_BONUS", BASE_WEIGHTS.DEFEND_NEAR_BONUS), 0, 10)),
     BLOCK_BASE: Math.round(clamp(pick("WEIGHTS.BLOCK_BASE", BASE_WEIGHTS.BLOCK_BASE), 0, 12)),
     EXPLORE_BASE: Math.round(clamp(pick("WEIGHTS.EXPLORE_BASE", BASE_WEIGHTS.EXPLORE_BASE), 0, 10)),
+    SUPPORT_BASE: Math.round(clamp(pick("WEIGHTS.SUPPORT_BASE", BASE_WEIGHTS.SUPPORT_BASE), 0, 12)),
     DIST_PEN: clamp(pick("WEIGHTS.DIST_PEN", BASE_WEIGHTS.DIST_PEN), 0.0005, 0.02),
+    CARRY_BASE: Math.round(clamp(pick("WEIGHTS.CARRY_BASE", BASE_WEIGHTS.CARRY_BASE), 6, 20)),
+    CARRY_ENEMY_NEAR_PEN: Math.round(clamp(pick("WEIGHTS.CARRY_ENEMY_NEAR_PEN", BASE_WEIGHTS.CARRY_ENEMY_NEAR_PEN), 0, 8)),
   } as const;
 
   return { TUNE, WEIGHTS };


### PR DESCRIPTION
## Summary
- handle SUPPORT_BASE, CARRY_BASE and CARRY_ENEMY_NEAR_PEN weights in Hybrid subject helpers
- test Hybrid ORDER coverage and ensure vectors round-trip cleanly

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a886c92334832ba467ad6e2e4f3dce