### PR TITLE
Fix stun cooldown tracking after planned actions

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -165,6 +165,23 @@ test('bot does not stun an already stunned enemy', () => {
   assert.equal(action.type, 'STUN');
 });
 
+test('stun cooldown enforced when stunCd missing', () => {
+  __mem.clear();
+  const ctx: any = {};
+  const self = { id: 1, x: 0, y: 0, state: 0 };
+  let obs: any = { tick: 0, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
+  let action = act(ctx, obs);
+  assert.equal(action.type, 'STUN');
+
+  obs = { tick: 10, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
+  action = act(ctx, obs);
+  assert.notEqual(action.type, 'STUN');
+
+  obs = { tick: 21, self, friends: [], enemies: [{ id: 2, x: 0, y: 0, state: 0, range: 0, stunnedFor: 0 }], ghostsVisible: [] };
+  action = act(ctx, obs);
+  assert.equal(action.type, 'STUN');
+});
+
 test('scoreAssign rewards ready stuns for SUPPORT tasks', () => {
   __mem.clear();
   const b: any = { id: 1, x: 0, y: 0 };

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -871,13 +871,16 @@ export function act(ctx: Ctx, obs: Obs) {
   }
   lastTick = tick;
   const me = obs.self;
-  const finish = <T>(act: T) => {
+  const m = M(me.id);
+  const finish = <T extends { type?: string }>(act: T) => {
+    if ((act as any)?.type === "STUN") {
+      m.stunReadyAt = tick + STUN_CD;
+    }
     if (process.env.MICRO_TIMING) {
       console.log(`[micro] t=${tick} b=${me.id} twoTurn=${microPerf.twoTurnMs.toFixed(3)}ms calls=${microPerf.twoTurnCalls}`);
     }
     return act;
   };
-  const m = M(me.id);
   const state = getState(ctx, obs);
   state.trackEnemies(obs.enemies, tick);
   state.decayGhosts();


### PR DESCRIPTION
## Summary
- update `finish` helper to record stun cooldown when returning STUN
- add regression test for stun cooldown without `stunCd`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a892afec10832b9f01531cc326f687