### PR TITLE
fix: ensure game step clones score state

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -137,6 +137,8 @@ const release: ActionsByTeam = { 0: [{ type: 'RELEASE' }], 1: [] } as any;
 const end = step(mid, release);
 const bEnd = end.busters[0];
 assert.equal(end.scores[0], 1);
+assert.equal(mid.scores[0], 0);
+assert.equal(state.scores[0], 0);
 assert.equal(bEnd.state, 0);
 assert.equal(bEnd.value, 0);
 });

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -253,6 +253,7 @@ export function step(state: GameState, actions: ActionsByTeam): GameState {
   const next: GameState = {
     ...state,
     tick: state.tick + 1,
+    scores: { ...state.scores },
     busters: state.busters.map(b => ({ ...b })),
     ghosts: state.ghosts.map(g => ({ ...g, engagedBy: 0 })),
     radarNextVision: {}, // ← will be filled by RADAR uses this tick, to apply on *next* tick


### PR DESCRIPTION
## Summary
- clone `scores` in game step to avoid mutating prior state
- assert previous state's scores remain unchanged when scoring

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a890c246bc832bbe5f2d384d256d2b