### PR TITLE
Restrict EJECT candidate to outside scoring radius

### DIFF
--- a/packages/agents/hybrid-bot.test.ts
+++ b/packages/agents/hybrid-bot.test.ts
@@ -222,6 +222,16 @@ test('does not eject when stun ready', () => {
   assert.notEqual(actRes.type, 'EJECT');
 });
 
+test('releases when carrying inside base radius', () => {
+  __mem.clear();
+  const ctx: any = { myBase: { x: 0, y: 0 } };
+  act(ctx, { tick: 0, self: { id: 99, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] });
+  const self = { id: 1, x: 1000, y: 1000, state: 1, stunCd: 5 };
+  const obs: any = { tick: 20, self, friends: [], enemies: [], ghostsVisible: [] };
+  const actRes = act(ctx, obs);
+  assert.equal(actRes.type, 'RELEASE');
+});
+
 test('buildTasks emits carry tasks for carriers', () => {
   const ctx: any = { tick: 0, myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } };
   const self: any = { id: 1, x: 1000, y: 1000, state: 1 };

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -546,8 +546,9 @@ export function executePlan(args: ExecuteArgs) {
 
   if (myTask) {
     const candidates: { act: any; base: number; deltas: number[]; tag: string; reason?: string }[] = [];
+    const dHome = dist(me.x, me.y, MY.x, MY.y);
 
-    if (carrying) {
+    if (carrying && dHome >= BASE_SCORE_RADIUS) {
       const ally = friends
         .filter(f => f.id !== me.id)
         .sort((a, b) => dist(a.x, a.y, MY.x, MY.y) - dist(b.x, b.y, MY.x, MY.y))[0];
@@ -557,7 +558,7 @@ export function executePlan(args: ExecuteArgs) {
       const ty = clamp(me.y + dy * EJECT_RADIUS, 0, H);
       const enemy = enemiesAll[0];
       const deltas: number[] = [];
-      deltas.push(micro(() => ejectDelta({ me, target: { x: tx, y: ty }, myBase: MY, ally }))); 
+      deltas.push(micro(() => ejectDelta({ me, target: { x: tx, y: ty }, myBase: MY, ally })));
       if (enemy) {
         deltas.push(
           micro(() =>
@@ -582,7 +583,6 @@ export function executePlan(args: ExecuteArgs) {
     }
 
     if (myTask.type === "CARRY") {
-      const dHome = dist(me.x, me.y, MY.x, MY.y);
       if (dHome < Math.min(TUNE.RELEASE_DIST, BASE_SCORE_RADIUS)) {
         candidates.push({ act: { type: "RELEASE" }, base: 120, deltas: [], tag: "RELEASE", reason: "carry" });
       }


### PR DESCRIPTION
## Summary
- Avoid evaluating EJECT actions when a carrier is already within the scoring radius
- Keep RELEASE actions prioritized near base
- Add regression test ensuring carriers release instead of eject when close to base

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a890e3fe14832bb4b4c7c919d0e4aa