### PR TITLE
Use ghost id for carrying value

### DIFF
--- a/packages/agents/cg-adapter.ts
+++ b/packages/agents/cg-adapter.ts
@@ -57,12 +57,12 @@ while (true) {
       x: me.x, y: me.y,
       stunCd: me.value,                // CG uses `value` for stun cooldown / stun time; good enough for gating STUN
       radarUsed: radarUsed.has(me.id), // we maintain locally
-      carrying: me.state === 1 ? {} : undefined
+      carrying: me.state === 1 ? me.value : undefined
     };
 
     const enemies = opp.map((e) => ({
       id: e.id, x: e.x, y: e.y,
-      carrying: e.state === 1 ? {} : undefined,
+      carrying: e.state === 1 ? e.value : undefined,
       range: d(self, e)
     }));
 

--- a/packages/agents/hybrid-bot.ts
+++ b/packages/agents/hybrid-bot.ts
@@ -74,7 +74,16 @@ type Ctx = {
   bustersPerPlayer?: number;
 };
 
-type Ent = { id: number; x: number; y: number; range?: number; state?: number; value?: number; stunnedFor?: number };
+type Ent = {
+  id: number;
+  x: number;
+  y: number;
+  range?: number;
+  state?: number;
+  value?: number;
+  carrying?: number | undefined;
+  stunnedFor?: number;
+};
 
 type Obs = {
   tick: number;

--- a/packages/sim-runner/src/subjects/hybrid.ts
+++ b/packages/sim-runner/src/subjects/hybrid.ts
@@ -41,7 +41,15 @@ const ORDER_IDX = ORDER.reduce<Record<string, number>>((acc, key, idx) => {
 }, {});
 
 type Pt = { x: number; y: number };
-type Ent = { id: number; x: number; y: number; range?: number; state?: number; value?: number };
+type Ent = {
+  id: number;
+  x: number;
+  y: number;
+  range?: number;
+  state?: number;
+  value?: number;
+  carrying?: number | undefined;
+};
 
 type Ctx = {
   tick: number;


### PR DESCRIPTION
## Summary
- pass along ghost id when busters carry
- add carrying field to entity types

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8988c3130832ba420dcd0f4a3d67b