### PR TITLE
fix: ensure flags require values

### DIFF
--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -22,12 +22,15 @@ import { loadEloTable, saveEloTable, updateElo } from './elo';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /* --------------------- CLI helpers --------------------- */
-function getFlag(args: string[], name: string, def?: any) {
+export function getFlag(args: string[], name: string, def?: any) {
   const i = args.indexOf(`--${name}`);
-  if (i >= 0) return args[i+1] ?? true;
+  if (i >= 0) {
+    const value = args[i + 1];
+    return value !== undefined ? value : def;
+  }
   return def;
 }
-function getBool(args: string[], name: string, def=false) {
+export function getBool(args: string[], name: string, def=false) {
   const i = args.indexOf(`--${name}`);
   return i >= 0 ? true : def;
 }

--- a/packages/sim-runner/src/cliFlags.test.ts
+++ b/packages/sim-runner/src/cliFlags.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getFlag } from './cli';
+
+test('getFlag returns provided value when flag has a value', () => {
+  const args = ['--foo', 'bar'];
+  assert.equal(getFlag(args, 'foo'), 'bar');
+});
+
+test('getFlag returns default when value is missing', () => {
+  const args = ['--foo'];
+  assert.equal(getFlag(args, 'foo', 'baz'), 'baz');
+});
+
+test('getFlag returns undefined when value is missing and no default', () => {
+  const args = ['--foo'];
+  assert.equal(getFlag(args, 'foo'), undefined);
+});


### PR DESCRIPTION
## Summary
- update `getFlag` to return default or undefined when a flag's value is missing
- export CLI flag helpers and add tests for flags with and without values

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a898d6b928832bb0a80d679408e8b7