### PR TITLE
feat(engine): skip stun when on cooldown

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -315,6 +315,19 @@ test('stun attempt consumes cooldown even if invalid or out of range', () => {
   assert.equal(postAttacker2.stunCd, RULES.STUN_COOLDOWN - 1);
 });
 
+test('stun action is ignored while on cooldown', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
+  const attacker = state.busters.find(b => b.teamId === 0)!;
+  const victim = state.busters.find(b => b.teamId === 1)!;
+  attacker.stunCd = 1; // cooldown active
+  const actions: ActionsByTeam = { 0: [{ type: 'STUN', busterId: victim.id }], 1: [] } as any;
+  const next = step(state, actions);
+  const postAttacker = next.busters.find(b => b.id === attacker.id)!;
+  const postVictim = next.busters.find(b => b.id === victim.id)!;
+  assert.equal(postAttacker.stunCd, 0); // only decremented
+  assert.equal(postVictim.state, 0); // not stunned
+});
+
 test('mutual stuns drop carried ghosts and stun both busters', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 2 });
   const b0 = state.busters.find(b => b.teamId === 0)!;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -119,9 +119,13 @@ export function collectIntents(
           break;
         case 'RELEASE':
         case 'RADAR':
-        case 'STUN':
         case 'BUST':
           intents.set(b.id, a);
+          break;
+        case 'STUN':
+          if (b.stunCd <= 0) {
+            intents.set(b.id, a);
+          }
           break;
         case 'EJECT': {
           const dx = a.x - b.x,

--- a/packages/engine/src/helpers.test.ts
+++ b/packages/engine/src/helpers.test.ts
@@ -22,6 +22,22 @@ test('collectIntents ignores stunned busters and clamps MOVE', () => {
   assert.ok(!intents.has(b1.id));
 });
 
+test('collectIntents skips STUN when on cooldown', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
+  const next = { ...state, busters: state.busters.map(b => ({ ...b })) };
+  const byTeam: Record<number, typeof next.busters> = { 0: [], 1: [] } as any;
+  next.busters.forEach(b => byTeam[b.teamId].push(b));
+  const attacker = next.busters[0];
+  const victim = next.busters.find(b => b.teamId === 1)!;
+  attacker.stunCd = 1; // still cooling down
+  const actions: ActionsByTeam = {
+    0: [{ type: 'STUN', busterId: victim.id }],
+    1: [],
+  } as any;
+  const intents = collectIntents(next, actions, byTeam as any);
+  assert.ok(!intents.has(attacker.id));
+});
+
 test('applyMoves respects speed limit', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 0 });
   const next = { ...state, busters: state.busters.map(b => ({ ...b })) };


### PR DESCRIPTION
## Summary
- ignore STUN actions when buster's stun cooldown is active so fallback actions can run
- add tests ensuring STUN commands are dropped during cooldown

## Testing
- `pnpm test` *(fails: @busters/agents test failed)*
- `pnpm --filter @busters/engine test`


------
https://chatgpt.com/codex/tasks/task_e_68a8991ff7f8832b8f7cc8f4bd2c98ff