### PR TITLE
Optimize perception distance handling

### DIFF
--- a/packages/engine/src/perception.test.ts
+++ b/packages/engine/src/perception.test.ts
@@ -90,3 +90,18 @@ test('enemy stun cooldown is hidden', () => {
   assert.equal(myEntity.value, 5);
   assert.equal(enemyEntity.value, 0);
 });
+
+test('ranges in observations are actual distances', () => {
+  const state = initGame({ seed: 1, bustersPerPlayer: 2, ghostCount: 1 });
+  const me = state.busters.find(b => b.teamId === 0)!;
+  const ally = state.busters.find(b => b.teamId === 0 && b.id !== me.id)!;
+  const ghost = state.ghosts[0];
+
+  me.x = 0; me.y = 0;
+  ally.x = 3; ally.y = 4; // distance 5
+  ghost.x = 6; ghost.y = 8; // distance 10
+
+  const obs = observationsForTeam(state, 0)[0];
+  assert.equal(obs.allies[0].range, 5);
+  assert.equal(obs.ghostsVisible[0].range, 10);
+});

--- a/packages/engine/src/perception.ts
+++ b/packages/engine/src/perception.ts
@@ -22,41 +22,41 @@ export function observationsForTeam(state: GameState, teamId: TeamId): Observati
     const vision = hasRadarVision ? RULES.RADAR_VISION : RULES.VISION;
     const vision2 = vision * vision;
 
-    const ghosts: { id: number; x: number; y: number; range: number; endurance: number }[] = [];
+    const ghosts: { id: number; x: number; y: number; range2: number; endurance: number }[] = [];
     for (const g of state.ghosts) {
       const d2 = dist2(me.x, me.y, g.x, g.y);
       if (d2 <= vision2) {
-        ghosts.push({ id: g.id, x: g.x, y: g.y, range: Math.sqrt(d2), endurance: g.endurance });
+        ghosts.push({ id: g.id, x: g.x, y: g.y, range2: d2, endurance: g.endurance });
       }
     }
-    ghosts.sort((a, b) => a.range - b.range);
+    ghosts.sort((a, b) => a.range2 - b.range2);
 
-    const allies: { id: number; x: number; y: number; range: number; stunnedFor: number; carrying?: number }[] = [];
+    const allies: { id: number; x: number; y: number; range2: number; stunnedFor: number; carrying?: number }[] = [];
     for (const b of my) {
       if (b.id === me.id) continue;
       const d2 = dist2(me.x, me.y, b.x, b.y);
       if (d2 <= vision2) {
-        allies.push({ id: b.id, x: b.x, y: b.y, range: Math.sqrt(d2), stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
+        allies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
       }
     }
-    allies.sort((a, b) => a.range - b.range);
+    allies.sort((a, b) => a.range2 - b.range2);
 
-    const enemies: { id: number; x: number; y: number; range: number; stunnedFor: number; carrying?: number }[] = [];
+    const enemies: { id: number; x: number; y: number; range2: number; stunnedFor: number; carrying?: number }[] = [];
     for (const b of opp) {
       const d2 = dist2(me.x, me.y, b.x, b.y);
       if (d2 <= vision2) {
-        enemies.push({ id: b.id, x: b.x, y: b.y, range: Math.sqrt(d2), stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
+        enemies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
       }
     }
-    enemies.sort((a, b) => a.range - b.range);
+    enemies.sort((a, b) => a.range2 - b.range2);
 
     res.push({
       tick: state.tick,
       self: { id: me.id, x: me.x, y: me.y, stunnedFor: me.state === 2 ? (me.value as number) : 0, carrying: me.state === 1 ? (me.value as number) : undefined, stunCd: me.stunCd, radarUsed: me.radarUsed },
       myBase: base,
-      ghostsVisible: ghosts,
-      allies,
-      enemies
+      ghostsVisible: ghosts.map(g => ({ id: g.id, x: g.x, y: g.y, range: Math.sqrt(g.range2), endurance: g.endurance })),
+      allies: allies.map(a => ({ id: a.id, x: a.x, y: a.y, range: Math.sqrt(a.range2), stunnedFor: a.stunnedFor, carrying: a.carrying })),
+      enemies: enemies.map(e => ({ id: e.id, x: e.x, y: e.y, range: Math.sqrt(e.range2), stunnedFor: e.stunnedFor, carrying: e.carrying }))
     });
   }
   return res;


### PR DESCRIPTION
## Summary
- store and sort squared distances before computing actual ranges
- add test ensuring observations expose true ranges

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8992bcb30832b96a27f3339084372