### PR TITLE
Refactor weight genome typing

### DIFF
--- a/packages/sim-runner/src/genomes/weightsGenome.ts
+++ b/packages/sim-runner/src/genomes/weightsGenome.ts
@@ -2,12 +2,15 @@ import { Weights, BOUNDS, DEFAULT_WEIGHTS } from "../../../agents/weights";
 
 export const WEIGHT_KEYS = Object.keys(DEFAULT_WEIGHTS) as (keyof Weights)[];
 
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
 export function clampWeights(w: Weights): Weights {
-  const out = { ...w };
+  const out: Weights = { ...w };
   for (const k of WEIGHT_KEYS) {
-    const {min,max} = BOUNDS[k];
-    // @ts-ignore
-    out[k] = Math.max(min, Math.min(max, out[k]));
+    const { min, max } = BOUNDS[k];
+    out[k] = clamp(out[k], min, max);
   }
   // enforce bustMin <= bustMax
   if (out.bustMin > out.bustMax) out.bustMin = out.bustMax;
@@ -15,18 +18,18 @@ export function clampWeights(w: Weights): Weights {
 }
 
 export function weightsToVec(w: Weights): number[] {
-  return WEIGHT_KEYS.map(k => (w as any)[k] as number);
+  return WEIGHT_KEYS.map(k => w[k]);
 }
 
 export function vecToWeights(vec: number[]): Weights {
-  const w: any = { ...DEFAULT_WEIGHTS };
-  for (let i=0;i<WEIGHT_KEYS.length;i++){
+  const w: Weights = { ...DEFAULT_WEIGHTS };
+  for (let i = 0; i < WEIGHT_KEYS.length; i++) {
     const k = WEIGHT_KEYS[i];
-    const v = vec[i] ?? (DEFAULT_WEIGHTS as any)[k];
-    const {min,max} = BOUNDS[k];
-    w[k] = Math.max(min, Math.min(max, v));
+    const v = vec[i] ?? DEFAULT_WEIGHTS[k];
+    const { min, max } = BOUNDS[k];
+    w[k] = clamp(v, min, max);
   }
   // order constraint
   if (w.bustMin > w.bustMax) w.bustMin = w.bustMax;
-  return w as Weights;
+  return w;
 }


### PR DESCRIPTION
## Summary
- remove `ts-ignore` from weight clamping and use typed helper
- type-safe conversions between weight objects and vectors

## Testing
- `pnpm exec tsc packages/sim-runner/src/genomes/weightsGenome.ts --noEmit`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8db1bb308832bb6b25f7c63c886d4