### PR TITLE
feat(shared): add rng helpers and refactor sim-runner

### DIFF
--- a/packages/shared/src/rng.test.ts
+++ b/packages/shared/src/rng.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { XorShift32 } from './rng';
+import { XorShift32, mulberry32, gaussian } from './rng';
 
 test('XorShift32 generates a deterministic sequence', () => {
   const rng = new XorShift32(1);
@@ -21,4 +21,18 @@ test('XorShift32 float handles max int without returning 1', () => {
   const rng = new XorShift32(1584200935);
   const v = rng.float();
   assert.ok(v < 1);
+});
+
+test('mulberry32 generates a deterministic sequence', () => {
+  const rng = mulberry32(1);
+  assert.ok(Math.abs(rng() - 0.6270739405881613) < 1e-9);
+  assert.ok(Math.abs(rng() - 0.002735721180215478) < 1e-9);
+});
+
+test('gaussian draws using provided RNG', () => {
+  const vals = [0.1, 0.2];
+  let i = 0;
+  const rng = () => vals[i++];
+  const g = gaussian(rng);
+  assert.ok(Math.abs(g - 0.6631399714746835) < 1e-9);
 });

--- a/packages/shared/src/rng.ts
+++ b/packages/shared/src/rng.ts
@@ -12,3 +12,20 @@ export class XorShift32 {
   }
   float(): number { return (this.int() >>> 0) / 0x100000000; }
 }
+
+export function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function gaussian(rng: () => number): number {
+  let u = 0, v = 0;
+  while (u === 0) u = rng();
+  while (v === 0) v = rng();
+  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+}

--- a/packages/sim-runner/src/algos/cem-utils.ts
+++ b/packages/sim-runner/src/algos/cem-utils.ts
@@ -1,20 +1,3 @@
-export function mulberry32(seed: number) {
-  let t = seed >>> 0;
-  return function () {
-    t += 0x6D2B79F5;
-    let r = Math.imul(t ^ (t >>> 15), 1 | t);
-    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
-    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-export function gaussian(rng: () => number) {
-  let u = 0, v = 0;
-  while (u === 0) u = rng();
-  while (v === 0) v = rng();
-  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
-}
-
 export function vecMean(vs: number[][]): number[] {
   const n = vs.length;
   const d = vs[0].length;

--- a/packages/sim-runner/src/algos/cem-weights.ts
+++ b/packages/sim-runner/src/algos/cem-weights.ts
@@ -8,7 +8,8 @@ import path from "path";
 import { vecToWeights, weightsToVec } from "../genomes/weightsGenome";
 import { DEFAULT_WEIGHTS, type Weights } from "../../../agents/weights";
 import { selectOpponentsPFSP } from "../pfsp";
-import { gaussian, mulberry32, vecMean, vecVar } from "./cem-utils";
+import { gaussian, mulberry32 } from "@busters/shared";
+import { vecMean, vecVar } from "./cem-utils";
 
 // Dimension of the flat weight vector
 const DIM = weightsToVec(DEFAULT_WEIGHTS).length;

--- a/packages/sim-runner/src/cli.ts
+++ b/packages/sim-runner/src/cli.ts
@@ -18,6 +18,7 @@ import {
 
 import { selectOpponentsPFSP } from './pfsp';
 import { loadEloTable, saveEloTable, updateElo } from './elo';
+import { mulberry32, gaussian, clamp } from '@busters/shared';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,24 +35,6 @@ export function getBool(args: string[], name: string, def=false) {
   const i = args.indexOf(`--${name}`);
   return i >= 0 ? true : def;
 }
-
-/* ---------------- RNG & math ---------------- */
-function mulberry32(seed: number) {
-  let t = seed >>> 0;
-  return function () {
-    t += 0x6D2B79F5;
-    let r = Math.imul(t ^ (t >>> 15), 1 | t);
-    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
-    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
-  };
-}
-function gaussian(rng: () => number) {
-  let u = 0, v = 0;
-  while (u === 0) u = rng();
-  while (v === 0) v = rng();
-  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
-}
-function clamp(v: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, v)); }
 
 /* ---------------- Opponent pool ---------------- */
 export async function resolveOppPool(

--- a/packages/sim-runner/src/ga.ts
+++ b/packages/sim-runner/src/ga.ts
@@ -6,6 +6,7 @@ import { Worker } from 'worker_threads';
 import { runEpisodes } from './runEpisodes';
 import { loadBotModule } from './loadBots';
 import { loadEloTable, saveEloTable, updateElo } from './elo';
+import { gaussian, clamp } from '@busters/shared';
 
 // ----- Elo helpers -----
 type EloTable = Record<string, number>;
@@ -58,16 +59,7 @@ const DEFAULT_MODULE = '@busters/agents/greedy';
     scout: '@busters/agents/scout',
   };
 
-function clamp(n: number, lo: number, hi: number) {
-  return Math.max(lo, Math.min(hi, n));
-}
-
-function randn() {
-  let u = 0, v = 0;
-  while (u === 0) u = Math.random();
-  while (v === 0) v = Math.random();
-  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
-}
+const randn = () => gaussian(Math.random);
 
 function sampleGenome(m: number[], s: number[]): Genome {
   const g = {


### PR DESCRIPTION
## Summary
- add mulberry32 and gaussian helpers to shared RNG module with tests
- refactor sim-runner modules to import shared RNG and math helpers
- clean up CEM utilities after moving RNG code to shared

## Testing
- `pnpm --filter @busters/shared test`
- `pnpm test` *(fails: @busters/agents@0.1.0 test: `tsx --test *.test.ts && pnpm bench:act`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db202d04832bb6c649135d068768