### PR TITLE
refactor: centralize Elo helpers

### DIFF
--- a/packages/sim-runner/src/elo.ts
+++ b/packages/sim-runner/src/elo.ts
@@ -8,7 +8,7 @@ export type EloTable = Record<string, number>;
 const DEFAULT_ELO = 1000;
 const K_FACTOR = 32;
 const ARTIFACTS = path.resolve("artifacts");
-const ELO_PATH = path.resolve(ARTIFACTS, "elo.json");
+const ELO_PATH = process.env.ELO_PATH || path.resolve(ARTIFACTS, "elo.json");
 
 /** Ensure artifacts dir exists */
 function ensureArtifactsDir() {

--- a/packages/sim-runner/src/pfsp.test.ts
+++ b/packages/sim-runner/src/pfsp.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectOpponentsPFSP } from './pfsp';
+import { EloTable, updateElo } from './elo';
+
+test('selectOpponentsPFSP picks opponent closest to target win rate', () => {
+  const elo: EloTable = { me: 1000, weak: 900, strong: 1100 };
+  const origRandom = Math.random;
+  Math.random = () => 0; // deterministic sampling
+  const picks = selectOpponentsPFSP({
+    meId: 'me',
+    candidates: ['weak', 'strong'],
+    elo,
+    n: 1,
+    target: 0.75,
+    temperature: 1e-6,
+  });
+  Math.random = origRandom;
+  assert.equal(picks.length, 1);
+  assert.equal(picks[0].id, 'weak');
+});
+
+test('updateElo adjusts ratings after a win', () => {
+  const tbl: EloTable = { a: 1000, b: 1000 };
+  updateElo(tbl, 'a', 'b', 1);
+  assert.equal(tbl.a, 1016);
+  assert.equal(tbl.b, 984);
+});
+

--- a/packages/sim-runner/src/pfsp.ts
+++ b/packages/sim-runner/src/pfsp.ts
@@ -1,41 +1,7 @@
 // packages/sim-runner/src/pfsp.ts
-import fs from "fs";
-import path from "path";
+import { EloTable, getElo, expectedScore, loadEloTable } from "./elo";
 
-export type EloTable = Record<string, number>;
 export type Opponent = { id: string; act?: Function };
-
-// ---- Tiny local Elo helpers (decoupled from ./elo.ts) ----
-const DEFAULT_ELO = 1000;
-const ELO_PATH = process.env.ELO_PATH || path.resolve("artifacts", "elo.json");
-
-function loadEloTable(): EloTable {
-  try {
-    const p = ELO_PATH;
-    if (fs.existsSync(p)) {
-      const raw = JSON.parse(fs.readFileSync(p, "utf-8"));
-      const out: EloTable = {};
-      for (const [k, v] of Object.entries(raw || {})) {
-        const n = Number(v);
-        if (Number.isFinite(n)) out[k] = n;
-      }
-      return out;
-    }
-  } catch {}
-  return {};
-}
-
-function getElo(elo: EloTable, id: string): number {
-  const v = elo[id];
-  if (typeof v === "number" && Number.isFinite(v)) return v;
-  // lazily default & remember so stability is consistent
-  return (elo[id] = DEFAULT_ELO);
-}
-
-// Elo expected score (A vs B)
-function expectedScore(rA: number, rB: number) {
-  return 1 / (1 + Math.pow(10, (rB - rA) / 400));
-}
 
 /**
  * PFSP selection using Elo:


### PR DESCRIPTION
## Summary
- unify Elo helpers in a dedicated `elo.ts` module with env path support
- update PFSP to use shared Elo utilities
- add tests for PFSP selection and Elo rating updates

## Testing
- `pnpm --filter @busters/sim-runner test`
- `pnpm test` *(fails: ENOENT no such file or directory, open '/workspace/busters/codingame_bot.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a8db3dbddc832b869938bf8ab438ad