### PR TITLE
feat: add BusterState enum

### DIFF
--- a/packages/agents/bench-act.ts
+++ b/packages/agents/bench-act.ts
@@ -1,6 +1,7 @@
 import { act, __mem, __pMem } from './hybrid-bot';
 import { resetMicroPerf } from './micro';
 import { performance } from 'node:perf_hooks';
+import { BusterState } from '@busters/shared';
 
 process.env.MICRO_TIMING = '1';
 
@@ -13,29 +14,29 @@ console.log = (...args: any[]) => {
 const scenarios = [
   {
     ctx: { myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } },
-    obs: { self: { id: 1, x: 0, y: 0, state: 0 }, friends: [], enemies: [], ghostsVisible: [] },
+    obs: { self: { id: 1, x: 0, y: 0, state: BusterState.Idle }, friends: [], enemies: [], ghostsVisible: [] },
   },
   {
     ctx: { myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } },
     obs: {
-      self: { id: 1, x: 4000, y: 4000, state: 0 },
+      self: { id: 1, x: 4000, y: 4000, state: BusterState.Idle },
       friends: [
-        { id: 2, x: 3000, y: 4000, state: 0 },
-        { id: 3, x: 3500, y: 4100, state: 0 },
+        { id: 2, x: 3000, y: 4000, state: BusterState.Idle },
+        { id: 3, x: 3500, y: 4100, state: BusterState.Idle },
       ],
       enemies: [
-        { id: 4, x: 4200, y: 4000, state: 0, range: 200 },
-        { id: 5, x: 5000, y: 4000, state: 0, range: 800 },
+        { id: 4, x: 4200, y: 4000, state: BusterState.Idle, range: 200 },
+        { id: 5, x: 5000, y: 4000, state: BusterState.Idle, range: 800 },
       ],
-      ghostsVisible: [{ id: 100, x: 4500, y: 4000, state: 0, range: 600 }],
+      ghostsVisible: [{ id: 100, x: 4500, y: 4000, state: BusterState.Idle, range: 600 }],
     },
   },
   {
     ctx: { myBase: { x: 0, y: 0 }, enemyBase: { x: 16000, y: 9000 } },
     obs: {
-      self: { id: 1, x: 6000, y: 6000, state: 1, carrying: 4, stunCd: 5 },
-      friends: [{ id: 2, x: 5000, y: 5500, state: 0 }],
-      enemies: [{ id: 3, x: 6100, y: 6000, state: 0, range: 100 }],
+      self: { id: 1, x: 6000, y: 6000, state: BusterState.Carrying, carrying: 4, stunCd: 5 },
+      friends: [{ id: 2, x: 5000, y: 5500, state: BusterState.Idle }],
+      enemies: [{ id: 3, x: 6100, y: 6000, state: BusterState.Idle, range: 100 }],
       ghostsVisible: [],
     },
   },

--- a/packages/agents/cg-adapter.ts
+++ b/packages/agents/cg-adapter.ts
@@ -11,6 +11,7 @@ declare function readline(): string;
 declare function print(s: string): void;
 
 import { act } from "./hybrid-bot";
+import { BusterState } from '@busters/shared';
 
 type Pt = { x: number; y: number };
 
@@ -57,12 +58,12 @@ while (true) {
       x: me.x, y: me.y,
       stunCd: me.value,                // CG uses `value` for stun cooldown / stun time; good enough for gating STUN
       radarUsed: radarUsed.has(me.id), // we maintain locally
-      carrying: me.state === 1 ? me.value : undefined
+      carrying: me.state === BusterState.Carrying ? me.value : undefined
     };
 
     const enemies = opp.map((e) => ({
       id: e.id, x: e.x, y: e.y,
-      carrying: e.state === 1 ? e.value : undefined,
+      carrying: e.state === BusterState.Carrying ? e.value : undefined,
       range: d(self, e)
     }));
 

--- a/packages/agents/micro.ts
+++ b/packages/agents/micro.ts
@@ -129,7 +129,6 @@ export function twoTurnContestDelta(opts: {
   canStunEnemy: boolean;
 }) {
   microPerf.twoTurnCalls++;
-  if (microOverBudget()) return 0;
   const { me, enemy, ghost, bustMin, bustMax, stunRange, canStunMe, canStunEnemy } = opts;
   const key = cacheKey(
     me.x,
@@ -147,6 +146,7 @@ export function twoTurnContestDelta(opts: {
   );
   const cached = twoTurnContestCache.get(key);
   if (cached !== undefined) return cached;
+  if (microOverBudget()) return 0;
   const t0 = performance.now();
   const me1 = step(me, ghost ?? enemy);
   const enemy1 = step(enemy, ghost ?? me);
@@ -193,7 +193,6 @@ export function twoTurnInterceptDelta(opts: {
   canStunEnemy: boolean;
 }) {
   microPerf.interceptCalls++;
-  if (microOverBudget()) return 0;
   const { me, enemy, myBase, stunRange, canStunMe, canStunEnemy } = opts;
   const key = cacheKey(
     me.x,
@@ -208,6 +207,7 @@ export function twoTurnInterceptDelta(opts: {
   );
   const cached = twoTurnInterceptCache.get(key);
   if (cached !== undefined) return cached;
+  if (microOverBudget()) return 0;
   const t0 = performance.now();
   const P = estimateInterceptPoint(me, enemy, myBase);
   const me1 = step(me, P);
@@ -282,7 +282,6 @@ export function twoTurnEjectDelta(opts: {
   canStunEnemy: boolean;
 }) {
   microPerf.ejectCalls++;
-  if (microOverBudget()) return 0;
   const { me, enemy, target, myBase, stunRange, canStunEnemy } = opts;
   const key = cacheKey(
     me.x,
@@ -298,6 +297,7 @@ export function twoTurnEjectDelta(opts: {
   );
   const cached = twoTurnEjectCache.get(key);
   if (cached !== undefined) return cached;
+  if (microOverBudget()) return 0;
   const t0 = performance.now();
   const me1 = step(me, target);
   const enemy1 = step(enemy, target);

--- a/packages/engine/src/cg-driver.test.ts
+++ b/packages/engine/src/cg-driver.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { initGame, step, ActionsByTeam } from './engine';
 import { parseAction, readLines } from './cg-driver';
-import { TEAM0_BASE, RULES, MAX_TICKS } from '@busters/shared';
+import { TEAM0_BASE, RULES, MAX_TICKS, BusterState } from '@busters/shared';
 import readline from 'node:readline';
 import { PassThrough } from 'node:stream';
 
@@ -27,7 +27,7 @@ test('loop ends when no ghosts remain and none are carried', () => {
       ? { 0: [{ type: 'BUST', ghostId: ghost.id }], 1: [] } as any
       : { 0: [{ type: 'RELEASE' }], 1: [] } as any;
     state = step(state, actions);
-    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === 1)) {
+    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === BusterState.Carrying)) {
       break;
     }
   }

--- a/packages/engine/src/cg-driver.ts
+++ b/packages/engine/src/cg-driver.ts
@@ -4,7 +4,7 @@ import readline from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { initGame, step, ActionsByTeam } from './engine';
 import { entitiesForTeam } from './perception';
-import { Action, TeamId, MAX_TICKS } from '@busters/shared';
+import { Action, TeamId, MAX_TICKS, BusterState } from '@busters/shared';
 
 export function parseAction(line: string): Action {
   const parts = line.trim().split(/\s+/);
@@ -165,7 +165,7 @@ async function main() {
     const actions: ActionsByTeam = { 0: actions0, 1: actions1 };
 
     state = step(state, actions);
-    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === 1)) {
+    if (state.ghosts.length === 0 && !state.busters.some(b => b.state === BusterState.Carrying)) {
       break;
     }
   }

--- a/packages/engine/src/perception.test.ts
+++ b/packages/engine/src/perception.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { initGame } from './engine';
 import { observationsForTeam, entitiesForTeam } from './perception';
-import { RULES } from '@busters/shared';
+import { RULES, BusterState } from '@busters/shared';
 
 test('radar vision reveals distant entities', () => {
   const state = initGame({ seed: 1, bustersPerPlayer: 1, ghostCount: 1 });
@@ -80,8 +80,8 @@ test('enemy stun cooldown is hidden', () => {
   enemy.stunCd = 7;
 
   // Neither buster is carrying, stunned or busting
-  me.state = 0;
-  enemy.state = 0;
+  me.state = BusterState.Idle;
+  enemy.state = BusterState.Idle;
 
   const list = entitiesForTeam(state, 0);
   const myEntity = list.find(e => e.id === me.id)!;

--- a/packages/engine/src/perception.ts
+++ b/packages/engine/src/perception.ts
@@ -1,4 +1,4 @@
-import { GameState, Observation, TeamId } from '@busters/shared';
+import { GameState, Observation, TeamId, BusterState } from '@busters/shared';
 import { RULES, TEAM0_BASE, TEAM1_BASE } from '@busters/shared';
 import { dist2 } from '@busters/shared';
 
@@ -36,7 +36,7 @@ export function observationsForTeam(state: GameState, teamId: TeamId): Observati
       if (b.id === me.id) continue;
       const d2 = dist2(me.x, me.y, b.x, b.y);
       if (d2 <= vision2) {
-        allies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
+        allies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === BusterState.Stunned ? (b.value as number) : 0, carrying: b.state === BusterState.Carrying ? (b.value as number) : undefined });
       }
     }
     allies.sort((a, b) => a.range2 - b.range2);
@@ -45,14 +45,14 @@ export function observationsForTeam(state: GameState, teamId: TeamId): Observati
     for (const b of opp) {
       const d2 = dist2(me.x, me.y, b.x, b.y);
       if (d2 <= vision2) {
-        enemies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === 2 ? (b.value as number) : 0, carrying: b.state === 1 ? (b.value as number) : undefined });
+        enemies.push({ id: b.id, x: b.x, y: b.y, range2: d2, stunnedFor: b.state === BusterState.Stunned ? (b.value as number) : 0, carrying: b.state === BusterState.Carrying ? (b.value as number) : undefined });
       }
     }
     enemies.sort((a, b) => a.range2 - b.range2);
 
     res.push({
       tick: state.tick,
-      self: { id: me.id, x: me.x, y: me.y, stunnedFor: me.state === 2 ? (me.value as number) : 0, carrying: me.state === 1 ? (me.value as number) : undefined, stunCd: me.stunCd, radarUsed: me.radarUsed },
+      self: { id: me.id, x: me.x, y: me.y, stunnedFor: me.state === BusterState.Stunned ? (me.value as number) : 0, carrying: me.state === BusterState.Carrying ? (me.value as number) : undefined, stunCd: me.stunCd, radarUsed: me.radarUsed },
       myBase: base,
       ghostsVisible: ghosts.map(g => ({ id: g.id, x: g.x, y: g.y, range: Math.sqrt(g.range2), endurance: g.endurance })),
       allies: allies.map(a => ({ id: a.id, x: a.x, y: a.y, range: Math.sqrt(a.range2), stunnedFor: a.stunnedFor, carrying: a.carrying })),
@@ -97,7 +97,7 @@ export function entitiesForTeam(state: GameState, teamId: TeamId): EntityView[] 
     y: b.y,
     entityType: teamId,
     state: b.state,
-    value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : b.stunCd
+    value: b.state === BusterState.Carrying || b.state === BusterState.Stunned || b.state === BusterState.Busting ? b.value : b.stunCd
   }));
 
   const enemies = Array.from(visibleEnemies.values())
@@ -108,7 +108,7 @@ export function entitiesForTeam(state: GameState, teamId: TeamId): EntityView[] 
       y: b.y,
       entityType: b.teamId,
       state: b.state,
-      value: b.state === 1 || b.state === 2 || b.state === 3 ? b.value : 0
+      value: b.state === BusterState.Carrying || b.state === BusterState.Stunned || b.state === BusterState.Busting ? b.value : 0
     }));
 
   const ghosts = Array.from(visibleGhosts.values()).map(g => ({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,12 @@
 export type TeamId = 0 | 1;
 
+export enum BusterState {
+  Idle = 0,
+  Carrying = 1,
+  Stunned = 2,
+  Busting = 3,
+}
+
 export type Action =
   | { type: 'MOVE'; x: number; y: number }
   | { type: 'BUST'; ghostId: number }
@@ -14,8 +21,7 @@ export type BusterPublicState = {
   teamId: TeamId;
   x: number;
   y: number;
-  // state: 0 none, 1 carrying, 2 stunned, 3 busting
-  state: 0 | 1 | 2 | 3;
+  state: BusterState;
   value: number; // ghostId if carrying, or stun ticks remaining if stunned, or target ghost id when busting
   stunCd: number; // cooldown until can stun again
   radarUsed: boolean;

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { TEAM0_BASE, TEAM1_BASE, RULES } from '@busters/shared';
+import { TEAM0_BASE, TEAM1_BASE, RULES, BusterState } from '@busters/shared';
 
 type FogMode = 'god' | 'team0' | 'team1';
 
@@ -139,12 +139,12 @@ export default function App() {
       ctx.fillStyle = b.teamId === 0 ? palette.t0 : palette.t1;
       ctx.beginPath(); ctx.arc(b.x, b.y, 22, 0, Math.PI * 2); ctx.fill();
 
-      if (b.state === 1) { // carrying
+      if (b.state === BusterState.Carrying) { // carrying
         ctx.strokeStyle = palette.carry;
         ctx.lineWidth = 3 * hair;
         ctx.strokeRect(b.x - 26, b.y - 26, 52, 52);
       }
-      if (b.state === 2) { // stunned
+      if (b.state === BusterState.Stunned) { // stunned
         ctx.strokeStyle = palette.stunned;
         ctx.lineWidth = 3 * hair;
         ctx.beginPath(); ctx.moveTo(b.x - 18, b.y - 18); ctx.lineTo(b.x + 18, b.y + 18); ctx.stroke();
@@ -154,8 +154,8 @@ export default function App() {
         ctx.fillStyle = '#e5e7eb';
         ctx.font = `${14 / Math.max(s, 1)}px ui-sans-serif, system-ui`;
         const status =
-          b.state === 2 ? `stun:${b.value}` :
-          b.state === 1 ? `carry:${b.value}` : '';
+          b.state === BusterState.Stunned ? `stun:${b.value}` :
+          b.state === BusterState.Carrying ? `carry:${b.value}` : '';
         const cd = b.stunCd > 0 ? ` cd:${b.stunCd}` : '';
         ctx.fillText(`B${b.id}${status?` ${status}`:''}${cd}`, b.x + 24, b.y - 10);
       }


### PR DESCRIPTION
## Summary
- define `BusterState` enum and replace numeric buster states across engine, agents, viewer, and sim runner
- adjust logic and tests to use enum values
- check micro rollouts cache before budget enforcement to maintain performance tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e1378038832baedcea5c30c6c52f