### PR TITLE
feat(shared): cache gaussian samples

### DIFF
--- a/packages/shared/src/rng.test.ts
+++ b/packages/shared/src/rng.test.ts
@@ -29,10 +29,29 @@ test('mulberry32 generates a deterministic sequence', () => {
   assert.ok(Math.abs(rng() - 0.002735721180215478) < 1e-9);
 });
 
-test('gaussian draws using provided RNG', () => {
+test('gaussian draws using provided RNG and caches second value', () => {
   const vals = [0.1, 0.2];
   let i = 0;
   const rng = () => vals[i++];
-  const g = gaussian(rng);
-  assert.ok(Math.abs(g - 0.6631399714746835) < 1e-9);
+  const g1 = gaussian(rng);
+  const g2 = gaussian(rng);
+  assert.ok(Math.abs(g1 - 0.6631399714746835) < 1e-9);
+  assert.ok(Math.abs(g2 - 2.0409349730505) < 1e-9);
+  assert.equal(i, 2); // rng consumed only once for both samples
+});
+
+test('gaussian distribution has ~0 mean and unit variance', () => {
+  const rng = mulberry32(123456);
+  const n = 100000;
+  let sum = 0;
+  let sumSq = 0;
+  for (let i = 0; i < n; i++) {
+    const g = gaussian(rng);
+    sum += g;
+    sumSq += g * g;
+  }
+  const mean = sum / n;
+  const variance = sumSq / n - mean * mean;
+  assert.ok(Math.abs(mean) < 0.05);
+  assert.ok(Math.abs(variance - 1) < 0.05);
 });

--- a/packages/shared/src/rng.ts
+++ b/packages/shared/src/rng.ts
@@ -23,9 +23,19 @@ export function mulberry32(seed: number): () => number {
   };
 }
 
+let hasSpare = false;
+let spare = 0;
+
 export function gaussian(rng: () => number): number {
+  if (hasSpare) {
+    hasSpare = false;
+    return spare;
+  }
   let u = 0, v = 0;
   while (u === 0) u = rng();
   while (v === 0) v = rng();
-  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+  const mag = Math.sqrt(-2.0 * Math.log(u));
+  spare = mag * Math.sin(2.0 * Math.PI * v);
+  hasSpare = true;
+  return mag * Math.cos(2.0 * Math.PI * v);
 }


### PR DESCRIPTION
## Summary
- generate gaussian pairs and cache spare sample for next call
- test gaussian caching and distribution statistics

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e28a8648832b82285b28944811f3