### PR TITLE
feat(pfsp): allow custom rng

### DIFF
--- a/packages/sim-runner/src/algos/cem-weights.ts
+++ b/packages/sim-runner/src/algos/cem-weights.ts
@@ -50,7 +50,7 @@ export async function trainCemWeights(opts: TrainOpts) {
     const evals: { idx: number; fit: number }[] = [];
     for (let i = 0; i < pop; i++) {
       const w = vecToWeights(popVecs[i]);
-      const opp = selectOpponentsPFSP({ meId: "weights", candidates: oppPool, n: 1 })[0].id;
+      const opp = selectOpponentsPFSP({ meId: "weights", candidates: oppPool, n: 1, rng })[0].id;
       const fit = await evaluate(w, opp);
       evals.push({ idx: i, fit });
     }

--- a/packages/sim-runner/src/pfsp.test.ts
+++ b/packages/sim-runner/src/pfsp.test.ts
@@ -3,11 +3,10 @@ import assert from 'node:assert/strict';
 
 import { selectOpponentsPFSP } from './pfsp';
 import { EloTable, updateElo } from './elo';
+import { mulberry32 } from '@busters/shared';
 
 test('selectOpponentsPFSP picks opponent closest to target win rate', () => {
   const elo: EloTable = { me: 1000, weak: 900, strong: 1100 };
-  const origRandom = Math.random;
-  Math.random = () => 0; // deterministic sampling
   const picks = selectOpponentsPFSP({
     meId: 'me',
     candidates: ['weak', 'strong'],
@@ -15,10 +14,19 @@ test('selectOpponentsPFSP picks opponent closest to target win rate', () => {
     n: 1,
     target: 0.75,
     temperature: 1e-6,
+    rng: () => 0,
   });
-  Math.random = origRandom;
   assert.equal(picks.length, 1);
   assert.equal(picks[0].id, 'weak');
+});
+
+test('selectOpponentsPFSP deterministic with seeded rng', () => {
+  const elo: EloTable = { me: 1000, a: 990, b: 1000, c: 1010 };
+  const rng1 = mulberry32(42);
+  const rng2 = mulberry32(42);
+  const picks1 = selectOpponentsPFSP({ meId: 'me', candidates: ['a', 'b', 'c'], elo, n: 2, rng: rng1 }).map(p => p.id);
+  const picks2 = selectOpponentsPFSP({ meId: 'me', candidates: ['a', 'b', 'c'], elo, n: 2, rng: rng2 }).map(p => p.id);
+  assert.deepEqual(picks1, picks2);
 });
 
 test('updateElo adjusts ratings after a win', () => {

--- a/packages/sim-runner/src/pfsp.ts
+++ b/packages/sim-runner/src/pfsp.ts
@@ -17,6 +17,7 @@ export function selectOpponentsPFSP(params: {
   n?: number;
   target?: number;
   temperature?: number;
+  rng?: () => number;
 }): Opponent[] {
   const envTarget = Number(process.env.PFSP_TARGET);
   const envTemp = Number(process.env.PFSP_TEMP);
@@ -29,6 +30,7 @@ export function selectOpponentsPFSP(params: {
 
   const meId = params.meId;
   const elo: EloTable = params.elo ?? loadEloTable();
+  const rng = params.rng ?? Math.random;
 
   // Normalize candidate list defensively
   let cand: Opponent[] = [];
@@ -69,7 +71,7 @@ export function selectOpponentsPFSP(params: {
   const picks: Opponent[] = [];
   const used = new Set<number>();
   while (picks.length < n && used.size < probs.length) {
-    let r = Math.random();
+    let r = rng();
     let idx = -1;
     for (let i = 0; i < probs.length; i++) {
       if (used.has(i)) continue;


### PR DESCRIPTION
## Summary
- allow injecting RNG into PFSP opponent selection for deterministic runs
- thread RNG through training utilities and eval helpers
- add tests for seeded RNG determinism

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e299790c832b8db3f858edb253c6