### PR TITLE
Reset stun cooldowns between episodes

### DIFF
--- a/packages/sim-runner/src/workerEval.test.ts
+++ b/packages/sim-runner/src/workerEval.test.ts
@@ -25,3 +25,23 @@ test('tracks stun cooldown when obs.self.stunCd is missing', () => {
   const after = bot.act(ctx, mkObs(20));
   assert.equal(after.type, 'STUN');
 });
+
+test('stun cooldown resets between episodes', () => {
+  const bot = genomeToBot({ radarTurn: 999, stunRange: 1760, releaseDist: 1600 });
+  const ctx = { myBase: { x: 0, y: 0 } } as any;
+  const mkObs = (tick: number) => ({
+    tick,
+    self: { id: 1, x: 0, y: 0, radarUsed: true },
+    enemies: [{ id: 2, range: 1000 }],
+    ghostsVisible: [],
+  }) as any;
+
+  const first = bot.act(ctx, mkObs(0));
+  assert.equal(first.type, 'STUN');
+
+  const next = bot.act(ctx, mkObs(1));
+  assert.notEqual(next.type, 'STUN');
+
+  const episode2 = bot.act(ctx, mkObs(0));
+  assert.equal(episode2.type, 'STUN');
+});

--- a/packages/sim-runner/src/workerEval.ts
+++ b/packages/sim-runner/src/workerEval.ts
@@ -27,6 +27,10 @@ export function genomeToBot(genome: Genome) {
   return {
     meta: { name: "EvolvedBot", version: "ga" },
     act(ctx: any, obs: any) {
+      if (obs.tick < lastTick) {
+        stunCd.clear();
+        lastTick = -1;
+      }
       if (obs.tick !== lastTick) {
         lastTick = obs.tick;
         for (const [id, cd] of stunCd.entries()) {


### PR DESCRIPTION
## Summary
- reset bot stun cooldown tracking when episode tick counter resets
- add regression test ensuring cooldowns do not persist across episodes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2a3bd94832b90ceacb7ff7b6054