### PR TITLE
feat: weight frontier with probabilities

### DIFF
--- a/packages/agents/lib/state.ts
+++ b/packages/agents/lib/state.ts
@@ -226,11 +226,23 @@ export class HybridState {
     return this.corridorProb[this.idxFromPoint(p)];
   }
 
-  /** Return center of least-visited cell (simple frontier heuristic) */
-  bestFrontier(): Pt {
-    let bestI = 0, bestV = this.visits[0];
-    for (let i = 1; i < this.visits.length; i++) {
-      if (this.visits[i] < bestV) { bestV = this.visits[i]; bestI = i; }
+  /**
+   * Return center of cell with lowest weighted score combining visit
+   * count, ghost probability and corridor probability.
+   *
+   * score = normalizedVisits - α * ghostProb - β * corridorProb
+   *
+   * Lower scores are preferred to favor less visited, high-probability
+   * regions.
+   */
+  bestFrontier(alpha = 1, beta = 1): Pt {
+    const maxVisit = Math.max(...this.visits);
+    let bestI = 0;
+    let bestScore = Infinity;
+    for (let i = 0; i < this.visits.length; i++) {
+      const visitScore = maxVisit > 0 ? this.visits[i] / maxVisit : 0;
+      const score = visitScore - alpha * this.ghostProb[i] - beta * this.corridorProb[i];
+      if (score < bestScore) { bestScore = score; bestI = i; }
     }
     const cy = Math.floor(bestI / this.cols);
     const cx = bestI % this.cols;

--- a/packages/agents/state.test.ts
+++ b/packages/agents/state.test.ts
@@ -80,6 +80,32 @@ test('updateCorridors tracks unseen carrier path and decays', () => {
   assert.ok(after < before);
 });
 
+test('bestFrontier combines visits with ghost and corridor probabilities', () => {
+  const st = new HybridState({ w: 16000, h: 9000 }, 2, 1);
+
+  // More visited cell should still be chosen if ghost weight is high enough
+  st.visits[0] = 2;
+  st.visits[1] = 0;
+  st.ghostProb[0] = 1;
+  st.ghostProb[1] = 0;
+  st.normalizeGhosts();
+  st.normalizeCorridors();
+  let p = st.bestFrontier(2, 0); // emphasize ghost probability
+  assert.deepEqual(p, { x: 4000, y: 4500 });
+
+  // Corridor probability influences selection when visits are equal
+  st.visits[0] = 0;
+  st.visits[1] = 0;
+  st.ghostProb[0] = 0;
+  st.ghostProb[1] = 0;
+  st.corridorProb[0] = 0;
+  st.corridorProb[1] = 1;
+  st.normalizeGhosts();
+  st.normalizeCorridors();
+  p = st.bestFrontier();
+  assert.deepEqual(p, { x: 12000, y: 4500 });
+});
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..', '..');
 const botFile = path.join(root, 'codingame_bot.js');


### PR DESCRIPTION
## Summary
- refine frontier selection by combining visit count with ghost and corridor probabilities
- test weighted frontier behavior for ghost hotspots and corridor tracking

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2dd4694832b92ffa5a36850a59f