### PR TITLE
Handle malformed CodinGame input

### DIFF
--- a/packages/agents/export-codingame.test.ts
+++ b/packages/agents/export-codingame.test.ts
@@ -9,22 +9,20 @@ import vm from 'node:vm';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..', '..');
 const outFile = path.join(root, 'codingame_bot.js');
-const hadFile = fs.existsSync(outFile);
-const original = hadFile ? fs.readFileSync(outFile, 'utf8') : undefined;
 
-test('exported bot runs under codingame_bot.js', () => {
-  // export using current hybrid parameters
+function runBot(inputs: string[]): string[] {
+  const hadFile = fs.existsSync(outFile);
+  const original = hadFile ? fs.readFileSync(outFile, 'utf8') : undefined;
   execSync(`pnpm exec tsx scripts/export-codingame.ts --from hybrid --out ${outFile}`, { cwd: root, stdio: 'inherit' });
 
   try {
     const code = fs.readFileSync(outFile, 'utf8');
-    const inputs = ['2', '0', '0', '0'];
     const outputs: string[] = [];
     vm.runInNewContext(code, {
       readline: () => inputs.shift(),
       print: (s: string) => outputs.push(String(s))
     });
-    assert.equal(outputs.length, 2, 'expected two action lines');
+    return outputs;
   } finally {
     if (hadFile && original !== undefined) {
       fs.writeFileSync(outFile, original);
@@ -32,4 +30,21 @@ test('exported bot runs under codingame_bot.js', () => {
       fs.unlinkSync(outFile);
     }
   }
+}
+
+test('cg-adapter export handles input lines', async (t) => {
+  await t.test('exported bot runs under codingame_bot.js', () => {
+    const outputs = runBot(['2', '0', '0', '0']);
+    assert.equal(outputs.length, 2, 'expected two action lines');
+  });
+
+  await t.test('aborts on truncated entity line', () => {
+    const outputs = runBot(['1', '0', '0', '1', '1 2 3 4 5']);
+    assert.deepEqual(outputs, ['WAIT']);
+  });
+
+  await t.test('aborts on malformed entity line', () => {
+    const outputs = runBot(['1', '0', '0', '1', 'a b c d e f']);
+    assert.deepEqual(outputs, ['WAIT']);
+  });
 });


### PR DESCRIPTION
## Summary
- Guard CodinGame adapter against missing lines and malformed entity tokens
- Return `WAIT` instead of throwing when parsing fails
- Test that exported bot handles truncated or bad entity lines

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2f98e1c832b94c8e2807c295a0d